### PR TITLE
feat : 게시물 Create 기능 개발

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/domain/Post.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Post.java
@@ -1,0 +1,46 @@
+package saramdle.blog.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+
+    @Id
+    @Column(name = "post_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private String author;
+
+    private String imgUrl;
+
+    private LocalDateTime createAt;
+
+    private LocalDateTime updateAt;
+
+    @Builder
+    private Post(String title, String content, String author, String imgUrl,
+                 LocalDateTime createAt, LocalDateTime updateAt) {
+        this.title = title;
+        this.content = content;
+        this.author = author;
+        this.imgUrl = imgUrl;
+        this.createAt = createAt;
+        this.updateAt = updateAt;
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/domain/PostRepository.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/PostRepository.java
@@ -1,0 +1,6 @@
+package saramdle.blog.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/back/blog/src/main/java/saramdle/blog/service/PostService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/PostService.java
@@ -1,0 +1,19 @@
+package saramdle.blog.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import saramdle.blog.domain.Post;
+import saramdle.blog.domain.PostRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository repository;
+
+    @Transactional
+    public Long save(Post post) {
+        return repository.save(post).getId();
+    }
+}

--- a/back/blog/src/test/java/saramdle/blog/service/PostServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/PostServiceTest.java
@@ -1,0 +1,24 @@
+package saramdle.blog.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import saramdle.blog.domain.Post;
+
+@SpringBootTest
+class PostServiceTest {
+
+    @Autowired
+    PostService postService;
+
+    @Test
+    @DisplayName("게시물을 저장합니다.")
+    void save() {
+        Post post = Post.builder().build();
+        Long savedId = postService.save(post);
+        assertThat(savedId).isEqualTo(post.getId());
+    }
+}


### PR DESCRIPTION
## PR Summary

- 게시물을 데이터베이스에 저장하는 기능을 개발하였습니다.
- resolves #6 

## Changes

- Post 엔티티 생성
- Post 리포지토리 생성
  - Spring Data Jpa가 제공하는 기능 사용
- Post 서비스 생성
  - 게시물 저장 기능 구현 및 테스트  

## Test Checklist

- [x] 게시물 저장 성공 테스트
