### PR TITLE
feat : 댓글 Create 기능 개발

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -30,20 +30,20 @@ public class Comment {
 
     private String imgUrl;
 
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
-    private LocalDateTime updateAt;
+    private LocalDateTime updatedAt;
 
     @Builder
     private Comment(Long id, String title, String contents, Post post, String author, String imgUrl,
-                    LocalDateTime createAt, LocalDateTime updateAt) {
+                    LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.title = title;
         this.contents = contents;
         this.post = post;
         this.author = author;
         this.imgUrl = imgUrl;
-        this.createAt = createAt;
-        this.updateAt = updateAt;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -1,0 +1,44 @@
+package saramdle.blog.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+
+    @Id
+    @Column
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String contents;
+
+    private String author;
+
+    private String imgUrl;
+
+    private LocalDateTime createAt;
+
+    private LocalDateTime updateAt;
+
+    @Builder
+    private Comment(Long id, String title, String contents, String author, String imgUrl,
+                    LocalDateTime createAt, LocalDateTime updateAt) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+        this.author = author;
+        this.imgUrl = imgUrl;
+        this.createAt = createAt;
+        this.updateAt = updateAt;
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -17,32 +17,26 @@ public class Comment {
     @Column
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    private String title;
-
-    private String contents;
+    
+    private String content;
 
     @ManyToOne
     @JoinColumn(name = "post_id")
     private Post post;
 
-    private String author;
-
-    private String imgUrl;
+    private String commentWriter;
 
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
 
     @Builder
-    private Comment(Long id, String title, String contents, Post post, String author, String imgUrl,
+    private Comment(Long id, String content, Post post, String commentWriter,
                     LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
-        this.title = title;
-        this.contents = contents;
+        this.content = content;
         this.post = post;
-        this.author = author;
-        this.imgUrl = imgUrl;
+        this.commentWriter = commentWriter;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -22,6 +22,10 @@ public class Comment {
 
     private String contents;
 
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
     private String author;
 
     private String imgUrl;
@@ -31,11 +35,12 @@ public class Comment {
     private LocalDateTime updateAt;
 
     @Builder
-    private Comment(Long id, String title, String contents, String author, String imgUrl,
+    private Comment(Long id, String title, String contents, Post post, String author, String imgUrl,
                     LocalDateTime createAt, LocalDateTime updateAt) {
         this.id = id;
         this.title = title;
         this.contents = contents;
+        this.post = post;
         this.author = author;
         this.imgUrl = imgUrl;
         this.createAt = createAt;

--- a/back/blog/src/main/java/saramdle/blog/domain/CommentRepository.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/CommentRepository.java
@@ -1,0 +1,6 @@
+package saramdle.blog.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository <Comment, Long> {
+}

--- a/back/blog/src/main/java/saramdle/blog/service/CommentService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/CommentService.java
@@ -1,0 +1,19 @@
+package saramdle.blog.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import saramdle.blog.domain.Comment;
+import saramdle.blog.domain.CommentRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository repository;
+
+    @Transactional
+    public Long save(Comment comment){
+        return repository.save(comment).getId();
+    }
+}

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -1,0 +1,25 @@
+package saramdle.blog.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import saramdle.blog.domain.Comment;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class CommentServiceTest {
+    @Autowired
+    CommentService commentService;
+
+    @DisplayName("댓글 저장")
+    @Test
+    void save() {
+        Comment comment = Comment.builder().build();
+        Long saveId = commentService.save(comment);
+        assertThat(saveId).isEqualTo(comment.getId());
+    }
+
+}

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -1,24 +1,44 @@
 package saramdle.blog.service;
 
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import saramdle.blog.domain.Comment;
+import saramdle.blog.domain.Post;
+
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class CommentServiceTest {
+
     @Autowired
     CommentService commentService;
+
+    @Autowired
+    PostService postService;
+
+
+    @BeforeEach
+    void beforeEach(){
+        Post post1 = Post.builder().build();
+        Long savedId1 = postService.save(post1);
+        Assertions.assertThat(post1.getId()).isEqualTo(savedId1);
+    }
 
     @DisplayName("댓글 저장")
     @Test
     void save() {
-        Comment comment = Comment.builder().build();
+        Post post = Post.builder().build();
+        postService.save(post);
+
+        Comment comment = Comment.builder().post(post).build();
         Long saveId = commentService.save(comment);
+
         assertThat(saveId).isEqualTo(comment.getId());
     }
 


### PR DESCRIPTION
## PR Summary

- 댓글을 Create하여 DB에 저장하는 기능을 개발했습니다. 
- resolves #1 

## Changes

- Comment 엔티티 생성
- Comment 리포지토리 생성
- Spring Data Jpa가 제공하는 기능 사용
- Comment 서비스 생성
- 댓글 저장 기능 구현 및 테스트
- Post <-> Comment 일대다 맵핑 

## Test Checklist
- [x] 댓글 저장 성공 테스트
