### PR TITLE
feat : Comment Create Read 기능 개발

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -18,17 +18,17 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
-    private String content;
+    private String contents;
 
     @ManyToOne
     @JoinColumn(name = "post_id")
     private Post post;
 
-    private String commentWriter;
+    private String author;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime createAt;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime updateAt;
 
     @Builder
     private Comment(Long id, String content, Post post, String commentWriter,

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -30,20 +30,20 @@ public class Comment {
 
     private String imgUrl;
 
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
-    private LocalDateTime updateAt;
+    private LocalDateTime updatedAt;
 
     @Builder
     private Comment(Long id, String title, String contents, Post post, String author, String imgUrl,
-                    LocalDateTime createAt, LocalDateTime updateAt) {
+                    LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.title = title;
         this.contents = contents;
         this.post = post;
         this.author = author;
         this.imgUrl = imgUrl;
-        this.createAt = createAt;
-        this.updateAt = updateAt;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -1,0 +1,44 @@
+package saramdle.blog.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+
+    @Id
+    @Column
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String contents;
+
+    private String author;
+
+    private String imgUrl;
+
+    private LocalDateTime createAt;
+
+    private LocalDateTime updateAt;
+
+    @Builder
+    private Comment(Long id, String title, String contents, String author, String imgUrl,
+                    LocalDateTime createAt, LocalDateTime updateAt) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+        this.author = author;
+        this.imgUrl = imgUrl;
+        this.createAt = createAt;
+        this.updateAt = updateAt;
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -18,26 +18,26 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
-    private String content;
+    private String contents;
 
     @ManyToOne
     @JoinColumn(name = "post_id")
     private Post post;
 
-    private String commentWriter;
+    private String author;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime createAt;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime updateAt;
 
     @Builder
-    private Comment(Long id, String content, Post post, String commentWriter,
-                    LocalDateTime createdAt, LocalDateTime updatedAt) {
+    private Comment(Long id, String contents, Post post, String author,
+                    LocalDateTime createAt, LocalDateTime updateAt) {
         this.id = id;
-        this.content = content;
+        this.contents = contents;
         this.post = post;
-        this.commentWriter = commentWriter;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
+        this.author = author;
+        this.createAt = createAt;
+        this.updateAt = updateAt;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -26,18 +26,18 @@ public class Comment {
 
     private String author;
 
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
-    private LocalDateTime updateAt;
+    private LocalDateTime updatedAt;
 
     @Builder
     private Comment(Long id, String contents, Post post, String author,
-                    LocalDateTime createAt, LocalDateTime updateAt) {
+                    LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.contents = contents;
         this.post = post;
         this.author = author;
-        this.createAt = createAt;
-        this.updateAt = updateAt;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -17,32 +17,26 @@ public class Comment {
     @Column
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    private String title;
-
-    private String contents;
+    
+    private String content;
 
     @ManyToOne
     @JoinColumn(name = "post_id")
     private Post post;
 
-    private String author;
-
-    private String imgUrl;
+    private String commentWriter;
 
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
 
     @Builder
-    private Comment(Long id, String title, String contents, Post post, String author, String imgUrl,
+    private Comment(Long id, String content, Post post, String commentWriter,
                     LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
-        this.title = title;
-        this.contents = contents;
+        this.content = content;
         this.post = post;
-        this.author = author;
-        this.imgUrl = imgUrl;
+        this.commentWriter = commentWriter;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -22,6 +22,10 @@ public class Comment {
 
     private String contents;
 
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
     private String author;
 
     private String imgUrl;
@@ -31,11 +35,12 @@ public class Comment {
     private LocalDateTime updateAt;
 
     @Builder
-    private Comment(Long id, String title, String contents, String author, String imgUrl,
+    private Comment(Long id, String title, String contents, Post post, String author, String imgUrl,
                     LocalDateTime createAt, LocalDateTime updateAt) {
         this.id = id;
         this.title = title;
         this.contents = contents;
+        this.post = post;
         this.author = author;
         this.imgUrl = imgUrl;
         this.createAt = createAt;

--- a/back/blog/src/main/java/saramdle/blog/domain/CommentRepository.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/CommentRepository.java
@@ -2,5 +2,9 @@ package saramdle.blog.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository <Comment, Long> {
+
+    List<Comment> findByPost_Id(Long postId);
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/CommentRepository.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/CommentRepository.java
@@ -1,0 +1,6 @@
+package saramdle.blog.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository <Comment, Long> {
+}

--- a/back/blog/src/main/java/saramdle/blog/service/CommentService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/CommentService.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import saramdle.blog.domain.Comment;
 import saramdle.blog.domain.CommentRepository;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class CommentService {
@@ -20,5 +22,14 @@ public class CommentService {
     @Transactional(readOnly = true)
     public Comment findComment(Long id) {
         return repository.findById(id).orElseThrow(() -> new IllegalStateException(NOT_FOUND_COMMENT));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Comment> findComments(Long postId) {
+        List<Comment> result = repository.findByPost_Id(postId);
+        if (result.isEmpty()) {
+            throw new IllegalStateException(NOT_FOUND_COMMENT);
+        }
+        return result;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/service/CommentService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/CommentService.java
@@ -1,0 +1,19 @@
+package saramdle.blog.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import saramdle.blog.domain.Comment;
+import saramdle.blog.domain.CommentRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository repository;
+
+    @Transactional
+    public Long save(Comment comment){
+        return repository.save(comment).getId();
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/service/CommentService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/CommentService.java
@@ -10,10 +10,15 @@ import saramdle.blog.domain.CommentRepository;
 @RequiredArgsConstructor
 public class CommentService {
 
+    private static final String NOT_FOUND_COMMENT = "해당 댓글을 찾을 수 없습니다.";
     private final CommentRepository repository;
 
     @Transactional
-    public Long save(Comment comment){
-        return repository.save(comment).getId();
+    public Long save(Comment comment) {
+        return repository.save(comment).getId();}
+
+    @Transactional(readOnly = true)
+    public Comment findComment(Long id) {
+        return repository.findById(id).orElseThrow(() -> new IllegalStateException(NOT_FOUND_COMMENT));
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/service/CommentService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/CommentService.java
@@ -27,9 +27,7 @@ public class CommentService {
     @Transactional(readOnly = true)
     public List<Comment> findComments(Long postId) {
         List<Comment> result = repository.findByPost_Id(postId);
-        if (result.isEmpty()) {
-            throw new IllegalStateException(NOT_FOUND_COMMENT);
-        }
+
         return result;
     }
 }

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -57,8 +57,7 @@ class CommentServiceTest {
 
         commentService.save(comment);
 
-        List<Comment> findedComments = commentService.findComments(comment.getPost().getId());
-
-        assertThat(findedComments.size()).isEqualTo(1);
+        List<Comment> foundComments = commentService.findComments(post.getId());
+        assertThat(foundComments.size()).isEqualTo(1);
     }
 }

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -1,0 +1,25 @@
+package saramdle.blog.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import saramdle.blog.domain.Comment;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class CommentServiceTest {
+    @Autowired
+    CommentService commentService;
+
+    @DisplayName("댓글 저장")
+    @Test
+    void save() {
+        Comment comment = Comment.builder().build();
+        Long saveId = commentService.save(comment);
+        assertThat(saveId).isEqualTo(comment.getId());
+    }
+
+}

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -1,24 +1,44 @@
 package saramdle.blog.service;
 
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import saramdle.blog.domain.Comment;
+import saramdle.blog.domain.Post;
+
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class CommentServiceTest {
+
     @Autowired
     CommentService commentService;
+
+    @Autowired
+    PostService postService;
+
+
+    @BeforeEach
+    void beforeEach(){
+        Post post1 = Post.builder().build();
+        Long savedId1 = postService.save(post1);
+        Assertions.assertThat(post1.getId()).isEqualTo(savedId1);
+    }
 
     @DisplayName("댓글 저장")
     @Test
     void save() {
-        Comment comment = Comment.builder().build();
+        Post post = Post.builder().build();
+        postService.save(post);
+
+        Comment comment = Comment.builder().post(post).build();
         Long saveId = commentService.save(comment);
+
         assertThat(saveId).isEqualTo(comment.getId());
     }
 

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -42,4 +42,16 @@ class CommentServiceTest {
         assertThat(saveId).isEqualTo(comment.getId());
     }
 
+    @Test
+    void findComment(){
+        Post post = Post.builder().build();
+        postService.save(post);
+
+        Comment comment = Comment.builder().post(post).build();
+        Long saveId  = commentService.save(comment);
+
+        Comment findedComment = commentService.findComment(saveId);
+
+        assertThat(saveId).isEqualTo(findedComment.getId());
+    }
 }

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import saramdle.blog.domain.Comment;
 import saramdle.blog.domain.Post;
-
+import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,9 +22,8 @@ class CommentServiceTest {
     @Autowired
     PostService postService;
 
-
     @BeforeEach
-    void beforeEach(){
+    void beforeEach() {
         Post post1 = Post.builder().build();
         Long savedId1 = postService.save(post1);
         Assertions.assertThat(post1.getId()).isEqualTo(savedId1);
@@ -43,15 +42,29 @@ class CommentServiceTest {
     }
 
     @Test
-    void findComment(){
+    void findComment() {
         Post post = Post.builder().build();
         postService.save(post);
 
         Comment comment = Comment.builder().post(post).build();
-        Long saveId  = commentService.save(comment);
+        Long saveId = commentService.save(comment);
 
         Comment findedComment = commentService.findComment(saveId);
 
         assertThat(saveId).isEqualTo(findedComment.getId());
+    }
+
+    @Test
+    void findComments() {
+        Post post = Post.builder().build();
+        postService.save(post);
+
+        Comment comment = Comment.builder().post(post).build();
+
+        commentService.save(comment);
+
+        List<Comment> findedComments = commentService.findComments(comment.getPost().getId());
+
+        assertThat(findedComments.size()).isEqualTo(1);
     }
 }

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -22,14 +22,6 @@ class CommentServiceTest {
     @Autowired
     PostService postService;
 
-
-    @BeforeEach
-    void beforeEach(){
-        Post post1 = Post.builder().build();
-        Long savedId1 = postService.save(post1);
-        Assertions.assertThat(post1.getId()).isEqualTo(savedId1);
-    }
-
     @DisplayName("댓글 저장")
     @Test
     void save() {


### PR DESCRIPTION
## PR Summary

- 댓글을 Create하여 DB에 저장하는 기능을 개발했습니다. 
- resolves #1 

## Changes

- Comment 엔티티 생성
- Comment 리포지토리 생성
- Spring Data Jpa가 제공하는 기능 사용
- Comment 서비스 생성
- 댓글 저장 기능 구현 및 테스트
- Post <-> Comment 일대다 맵핑 
- 엔티티 필드 수정
- 테스트 파일 미 사용 코드(beforeEach함수) 제거
- 댓글 ID로 댓글 조회 기능
- Post ID로 댓글 조회 기능


## Test Checklist
- [x] 댓글 저장 테스트 성공
- [x] 댓글 조회 테스트 성공
