### PR TITLE
feat : 댓글 Update 기능 구현

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -17,7 +17,7 @@ public class Comment {
     @Column
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
+
     private String contents;
 
     @ManyToOne
@@ -40,4 +40,9 @@ public class Comment {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
+
+    public void update(String contents) {
+        this.contents = contents;
+    }
+
 }

--- a/back/blog/src/main/java/saramdle/blog/service/CommentService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/CommentService.java
@@ -17,7 +17,8 @@ public class CommentService {
 
     @Transactional
     public Long save(Comment comment) {
-        return repository.save(comment).getId();}
+        return repository.save(comment).getId();
+    }
 
     @Transactional(readOnly = true)
     public Comment findComment(Long id) {
@@ -29,5 +30,13 @@ public class CommentService {
         List<Comment> result = repository.findByPost_Id(postId);
 
         return result;
+    }
+
+    @Transactional
+    public Long updateComment(Long commentId, Comment updateParam) {
+        Comment comment = findComment(commentId);
+        comment.update(updateParam.getContents());
+
+        return commentId;
     }
 }

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -66,7 +66,6 @@ class CommentServiceTest {
 
         Comment comment = Comment.builder().post(post).build();
         Long commentId = commentService.save(comment);
-        System.out.println(commentId);
 
         Comment newComment = Comment.builder().contents("Hello World").build();
 

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -1,17 +1,15 @@
 package saramdle.blog.service;
 
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import saramdle.blog.domain.Comment;
 import saramdle.blog.domain.Post;
+
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class CommentServiceTest {
@@ -59,5 +57,23 @@ class CommentServiceTest {
 
         List<Comment> foundComments = commentService.findComments(post.getId());
         assertThat(foundComments.size()).isEqualTo(1);
+    }
+
+    @Test
+    void updateComments() {
+        Post post = Post.builder().build();
+        postService.save(post);
+
+        Comment comment = Comment.builder().post(post).build();
+        Long commentId = commentService.save(comment);
+        System.out.println(commentId);
+
+        Comment newComment = Comment.builder().contents("Hello World").build();
+
+        Long updatedCommentId = commentService.updateComment(commentId, newComment);
+
+        Comment result = commentService.findComment(updatedCommentId);
+
+        assertThat(result.getContents()).isEqualTo("Hello World");
     }
 }


### PR DESCRIPTION
## PR Summary
- Comment Entity에 변수명 createdAt, updatedAt으로 수정했습니다. 
- 댓글을 Update하여 DB에 저장하는 기능을 개발했습니다.
- 댓글 내용 수정에 대한 기능을 테스트 코드 작성했고 테스트 결과 이상 없습니다.

- resolves #20 



## Test Checklist

- [x] 댓글 Contents 수정 성공 테스트


