### PR TITLE
feat : 댓글 Delete 기능 구현

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/service/CommentService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/CommentService.java
@@ -39,4 +39,11 @@ public class CommentService {
 
         return commentId;
     }
+
+    @Transactional
+    public void deleteComment(Long commentId) {
+        Comment comment = findComment(commentId);
+        repository.delete(comment);
+    }
+
 }

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -32,7 +32,6 @@ class CommentServiceTest {
 
         assertThat(saveId).isEqualTo(comment.getId());
     }
-
     @Test
     void findComment() {
         Post post = Post.builder().build();
@@ -74,5 +73,22 @@ class CommentServiceTest {
         Comment result = commentService.findComment(updatedCommentId);
 
         assertThat(result.getContents()).isEqualTo("Hello World");
+    }
+
+    @Test
+    void deleteComment() {
+        Post post = Post.builder().build();
+        postService.save(post);
+
+        Comment comment = Comment.builder().post(post).build();
+        Long commentId = commentService.save(comment);
+
+        commentService.deleteComment(commentId);
+
+        try {
+            commentService.findComment(commentId);
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage()).isEqualTo("해당 댓글을 찾을 수 없습니다.");
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

- 댓글ID를 통해서 댓글을 찾아서 삭제하는 기능을 구현했습니다.
- resolves #22 

## Changes

- CommentService파일 내에 deleteComment 함수가 추가되었습니다.
- CommentServiceTest 파일 내에 deleteComment함수를 테스트 합니다. 

## Test Checklist

- [x] 댓글 ID를 통한 댓글 삭제 기능 성공 테스트
