### PR TITLE
feat : 생성, 수정시간을 자동으로 설정해주는 BaseTimeEntity 적용

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/BlogApplication.java
+++ b/back/blog/src/main/java/saramdle/blog/BlogApplication.java
@@ -2,7 +2,9 @@ package saramdle.blog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BlogApplication {
 

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -1,17 +1,22 @@
 package saramdle.blog.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
-import java.time.LocalDateTime;
+import saramdle.blog.domain.common.BaseTimeEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment {
+public class Comment extends BaseTimeEntity {
 
     @Id
     @Column
@@ -26,23 +31,15 @@ public class Comment {
 
     private String author;
 
-    private LocalDateTime createdAt;
-
-    private LocalDateTime updatedAt;
-
     @Builder
-    private Comment(Long id, String contents, Post post, String author,
-                    LocalDateTime createdAt, LocalDateTime updatedAt) {
+    private Comment(Long id, String contents, Post post, String author) {
         this.id = id;
         this.contents = contents;
         this.post = post;
         this.author = author;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
     }
 
     public void update(String contents) {
         this.contents = contents;
     }
-
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/Post.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Post.java
@@ -1,6 +1,5 @@
 package saramdle.blog.domain;
 
-import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -10,11 +9,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import saramdle.blog.domain.common.BaseTimeEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Post {
+public class Post extends BaseTimeEntity {
 
     @Id
     @Column(name = "post_id")
@@ -29,19 +29,12 @@ public class Post {
 
     private String imgUrl;
 
-    private LocalDateTime createdAt;
-
-    private LocalDateTime updatedAt;
-
     @Builder
-    private Post(String title, String contents, String author, String imgUrl,
-                 LocalDateTime createdAt, LocalDateTime updatedAt) {
+    private Post(String title, String contents, String author, String imgUrl) {
         this.title = title;
         this.contents = contents;
         this.author = author;
         this.imgUrl = imgUrl;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
     }
 
     public void update(String title, String author, String contents) {

--- a/back/blog/src/main/java/saramdle/blog/domain/common/BaseTimeEntity.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/common/BaseTimeEntity.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseTimeEntity {
+public abstract class BaseTimeEntity {
 
     @CreatedDate
     @Column(updatable = false)

--- a/back/blog/src/main/java/saramdle/blog/domain/common/BaseTimeEntity.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/common/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package saramdle.blog.domain.common;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/back/blog/src/test/java/saramdle/blog/domain/common/BaseTimeEntityTest.java
+++ b/back/blog/src/test/java/saramdle/blog/domain/common/BaseTimeEntityTest.java
@@ -2,6 +2,7 @@ package saramdle.blog.domain.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,5 +43,37 @@ class BaseTimeEntityTest {
 
         assertThat(findComment.getCreatedAt()).isNotNull();
         assertThat(findComment.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("게시물을 수정하면 수정시간이 자동으로 변경된다.")
+    void updateTimeOfPost() {
+        Post post = Post.builder().title("제목1").contents("내용1").build();
+        Long postId = postService.save(post);
+        Post oldPost = postService.findPost(postId);
+
+        Post updatePost = Post.builder().title("제목2").contents("내용2").build();
+        postService.update(postId, updatePost);
+        Post newPost = postService.findPost(postId);
+
+        LocalDateTime oldTime = oldPost.getUpdatedAt();
+        LocalDateTime newTime = newPost.getUpdatedAt();
+        assertThat(newTime).isAfter(oldTime);
+    }
+
+    @Test
+    @DisplayName("댓글을 수정하면 수정시간이 자동으로 변경된다.")
+    void updateTimeOfComment() {
+        Comment comment = Comment.builder().contents("내용1").build();
+        Long commentId = commentService.save(comment);
+        Comment oldComment = commentService.findComment(commentId);
+
+        Comment updateComment = Comment.builder().contents("내용2").build();
+        commentService.updateComment(commentId, updateComment);
+        Comment newComment = commentService.findComment(commentId);
+
+        LocalDateTime oldTime = oldComment.getUpdatedAt();
+        LocalDateTime newTime = newComment.getUpdatedAt();
+        assertThat(newTime).isAfter(oldTime);
     }
 }

--- a/back/blog/src/test/java/saramdle/blog/domain/common/BaseTimeEntityTest.java
+++ b/back/blog/src/test/java/saramdle/blog/domain/common/BaseTimeEntityTest.java
@@ -1,0 +1,46 @@
+package saramdle.blog.domain.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import saramdle.blog.domain.Comment;
+import saramdle.blog.domain.Post;
+import saramdle.blog.service.CommentService;
+import saramdle.blog.service.PostService;
+
+@SpringBootTest
+class BaseTimeEntityTest {
+
+    @Autowired
+    PostService postService;
+
+    @Autowired
+    CommentService commentService;
+
+    @Test
+    @DisplayName("게시물을 저장하면 생성, 수정시간이 자동으로 생성된다.")
+    void generateTimeOfPost() {
+        Post post = Post.builder().build();
+        Long postId = postService.save(post);
+
+        Post findPost = postService.findPost(postId);
+
+        assertThat(findPost.getCreatedAt()).isNotNull();
+        assertThat(findPost.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("댓글을 저장하면 생성, 수정시간이 자동으로 생성된다.")
+    void generateTimeOfComment() {
+        Comment comment = Comment.builder().build();
+        Long commentId = commentService.save(comment);
+
+        Comment findComment = commentService.findComment(commentId);
+
+        assertThat(findComment.getCreatedAt()).isNotNull();
+        assertThat(findComment.getUpdatedAt()).isNotNull();
+    }
+}


### PR DESCRIPTION
## PR Summary

- 도메인에 공통으로 들어가는 `createdAt`, `updatedAt` 필드의 중복을 줄이기 위해 BaseTimeEntity 클래스를 만들어 Post, Comment 엔티티에 적용하였습니다.
- resolves #25 

## Changes

- 공통 속성으로 사용되는 BaseTimeEntity 클래스를 생성하였습니다.
- Post가 BaseTimeEntity를 상속해 `createdAt`, `updatedAt` 컬럼을 자동으로 관리하도록 변경하였습니다.
- Comment가 BaseTimeEntity를 상속해 `createdAt`, `updatedAt` 컬럼을 자동으로 관리하도록 변경하였습니다.
- JPA Auditing 기능을 활성화하기 위해 메인 클래스에 `@EnableJpaAuditing` 애노테이션을 추가하였습니다.
