### PR TITLE
feat : 게시물 컨트롤러 개발

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/controller/PostController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/PostController.java
@@ -1,0 +1,45 @@
+package saramdle.blog.controller;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import saramdle.blog.domain.Post;
+import saramdle.blog.domain.PostSaveDto;
+import saramdle.blog.service.PostService;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+@RestController
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<String> newPost(@RequestBody PostSaveDto postSaveDto) {
+        Post post = toEntity(postSaveDto);
+        Long postId = postService.save(post);
+
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(postId)
+                .toUri();
+
+        return ResponseEntity.created(location).body("게시물 등록 성공");
+    }
+
+    private Post toEntity(PostSaveDto postSaveDto) {
+        return Post.builder()
+                .title(postSaveDto.getTitle())
+                .contents(postSaveDto.getContents())
+                .author(postSaveDto.getAuthor())
+                .imgUrl(postSaveDto.getImgUrl())
+                .build();
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/controller/PostController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/PostController.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,6 +64,12 @@ public class PostController {
         Long postId = postService.update(id, toEntity(postRequestDto));
         Post post = postService.findPost(postId);
         return ResponseEntity.ok(toDto(post));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> delete(@PathVariable long id) {
+        postService.delete(id);
+        return ResponseEntity.ok("게시물 삭제 성공");
     }
 
     private PostResponseDto toDto(Post post) {

--- a/back/blog/src/main/java/saramdle/blog/controller/PostController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/PostController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,6 +48,14 @@ public class PostController {
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(dtos);
+    }
+
+    @GetMapping
+    @RequestMapping("/{id}")
+    public ResponseEntity<PostResponseDto> detail(@PathVariable long id) {
+        Post post = postService.findPost(id);
+        PostResponseDto dto = toDto(post);
+        return ResponseEntity.ok(dto);
     }
 
     private PostResponseDto toDto(Post post) {

--- a/back/blog/src/main/java/saramdle/blog/controller/PostController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/PostController.java
@@ -1,15 +1,19 @@
 package saramdle.blog.controller;
 
 import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import saramdle.blog.domain.Post;
+import saramdle.blog.domain.PostResponseDto;
 import saramdle.blog.domain.PostSaveDto;
 import saramdle.blog.service.PostService;
 
@@ -32,6 +36,28 @@ public class PostController {
                 .toUri();
 
         return ResponseEntity.created(location).body("게시물 등록 성공");
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PostResponseDto>> list() {
+        List<Post> posts = postService.findPosts();
+
+        List<PostResponseDto> dtos = posts.stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(dtos);
+    }
+
+    private PostResponseDto toDto(Post post) {
+        return PostResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .contents(post.getContents())
+                .author(post.getAuthor())
+                .imgUrl(post.getImgUrl())
+                .createdAt(post.getCreatedAt())
+                .build();
     }
 
     private Post toEntity(PostSaveDto postSaveDto) {

--- a/back/blog/src/main/java/saramdle/blog/controller/PostController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/PostController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,12 +51,18 @@ public class PostController {
         return ResponseEntity.ok(dtos);
     }
 
-    @GetMapping
-    @RequestMapping("/{id}")
+    @GetMapping("/{id}")
     public ResponseEntity<PostResponseDto> detail(@PathVariable long id) {
         Post post = postService.findPost(id);
         PostResponseDto dto = toDto(post);
         return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<PostResponseDto> update(@PathVariable long id, @RequestBody PostRequestDto postRequestDto) {
+        Long postId = postService.update(id, toEntity(postRequestDto));
+        Post post = postService.findPost(postId);
+        return ResponseEntity.ok(toDto(post));
     }
 
     private PostResponseDto toDto(Post post) {

--- a/back/blog/src/main/java/saramdle/blog/controller/PostController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/PostController.java
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import saramdle.blog.domain.Post;
+import saramdle.blog.domain.PostRequestDto;
 import saramdle.blog.domain.PostResponseDto;
-import saramdle.blog.domain.PostSaveDto;
 import saramdle.blog.service.PostService;
 
 @Slf4j
@@ -27,8 +27,8 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping
-    public ResponseEntity<String> newPost(@RequestBody PostSaveDto postSaveDto) {
-        Post post = toEntity(postSaveDto);
+    public ResponseEntity<String> newPost(@RequestBody PostRequestDto postRequestDto) {
+        Post post = toEntity(postRequestDto);
         Long postId = postService.save(post);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
@@ -69,12 +69,12 @@ public class PostController {
                 .build();
     }
 
-    private Post toEntity(PostSaveDto postSaveDto) {
+    private Post toEntity(PostRequestDto postRequestDto) {
         return Post.builder()
-                .title(postSaveDto.getTitle())
-                .contents(postSaveDto.getContents())
-                .author(postSaveDto.getAuthor())
-                .imgUrl(postSaveDto.getImgUrl())
+                .title(postRequestDto.getTitle())
+                .contents(postRequestDto.getContents())
+                .author(postRequestDto.getAuthor())
+                .imgUrl(postRequestDto.getImgUrl())
                 .build();
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/PostRequestDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/PostRequestDto.java
@@ -5,19 +5,16 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 게시물 저장 요청
- */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostSaveDto {
+public class PostRequestDto {
     private String title;
     private String contents;
     private String author;
     private String imgUrl;
 
     @Builder
-    private PostSaveDto(String title, String contents, String author, String imgUrl) {
+    private PostRequestDto(String title, String contents, String author, String imgUrl) {
         this.title = title;
         this.contents = contents;
         this.author = author;

--- a/back/blog/src/main/java/saramdle/blog/domain/PostResponseDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/PostResponseDto.java
@@ -1,0 +1,29 @@
+package saramdle.blog.domain;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostResponseDto {
+    private Long id;
+    private String title;
+    private String contents;
+    private String author;
+    private String imgUrl;
+    private LocalDateTime createdAt;
+
+    @Builder
+    private PostResponseDto(Long id, String title, String contents, String author,
+                            String imgUrl, LocalDateTime createdAt) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+        this.author = author;
+        this.imgUrl = imgUrl;
+        this.createdAt = createdAt;
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/domain/PostSaveDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/PostSaveDto.java
@@ -1,0 +1,26 @@
+package saramdle.blog.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 게시물 저장 요청
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostSaveDto {
+    private String title;
+    private String contents;
+    private String author;
+    private String imgUrl;
+
+    @Builder
+    private PostSaveDto(String title, String contents, String author, String imgUrl) {
+        this.title = title;
+        this.contents = contents;
+        this.author = author;
+        this.imgUrl = imgUrl;
+    }
+}


### PR DESCRIPTION
## PR Summary

- 클라이언트 요청을 처리하는 게시물 컨트롤러를 개발하였습니다.
- resolves #28 

## Changes

- 클라이언트 요청 데이터 전달을 위한 `PostRequestDto` 생성
- 클라이언트 응답 데이터 전달을 위한 `PostResponseDto` 생성
- 게시물 등록 요청을 처리하는 컨트롤러 구현 → `newPost()`
- 게시물 목록 조회 요청을 처리하는 컨트롤러 구현 → `list()`
- 게시물 상세 조회 요청을 처리하는 컨트롤러 구현 → `detail()`
- 게시물 수정 요청을 처리하는 컨트롤러 구현 → `update()`
- 게시물 삭제 요청을 처리하는 컨트롤러 구현 → `delete()`

## Test Checklist

- [x] **게시물 등록 성공 테스트**
HTTP 헤더의 Location으로 만들어진 리소스의 위치를 전달합니다.
<img width="1090" alt="image" src="https://user-images.githubusercontent.com/91456818/227472040-71aaf088-a855-4765-acf0-fd4984759b28.png">

- [x] **게시물 목록 조회 요청 성공 테스트**
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/91456818/227472958-194551c8-1c5b-477e-a6bc-3726643d139d.png">

- [x] **게시물 상세 조회 요청 성공 테스트**
<img width="1087" alt="image" src="https://user-images.githubusercontent.com/91456818/227473103-3614efb9-932f-4817-ae0a-0adecf671961.png">

- [x] **게시물 수정 요청 성공 테스트**
<img width="1090" alt="image" src="https://user-images.githubusercontent.com/91456818/227473507-8df7f49f-f6bb-4e6f-b37e-973822abe128.png">

- [x] **게시물 삭제 요청 성공 테스트**
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/91456818/227473699-b533d0ef-b738-4e2c-ab79-bd0c5d2b429e.png">

## ETC

- Dto ↔️ Entity간의 변환을 컨트롤러 계층이 아닌 서비스 계층에서 진행하도록 리팩토링 예정입니다.
- 예외 처리를 진행할 예정입니다.
