### PR TITLE
feat : 댓글 컨트롤러 개발

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
@@ -45,6 +45,14 @@ public class CommentController {
 
         return ResponseEntity.created(location).body("댓글 작성이 완료되었습니다.");
     }
+
+    @PutMapping("/{commentId}")
+    @ResponseBody
+    public ResponseEntity<CommentResponseDto> updateComment(@RequestBody CommentRequestDto commentRequestDto, @PathVariable Long commentId) {
+        commentId = commentService.updateComment(commentId, toEntity(commentRequestDto));
+        Comment comment = commentService.findComment(commentId);
+        return ResponseEntity.ok(toDto(comment));
+    }
     
     private Comment toEntity(CommentRequestDto commentRequestDto) {
         return Comment.builder()

--- a/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
@@ -1,0 +1,47 @@
+package saramdle.blog.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import saramdle.blog.domain.Comment;
+import saramdle.blog.domain.CommentRequestDto;
+import saramdle.blog.service.CommentService;
+import saramdle.blog.service.PostService;
+
+import java.net.URI;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/comments")
+public class CommentController {
+    private final CommentService commentService;
+    private final PostService postService;
+
+    @PostMapping
+    @ResponseBody
+    public ResponseEntity<String> postComment(@RequestBody CommentRequestDto commentRequestDto) {
+        Comment comment = toEntity(commentRequestDto);
+
+        Long commentId = commentService.save(comment);
+
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(commentId)
+                .toUri();
+
+        return ResponseEntity.created(location).body("댓글 작성이 완료되었습니다.");
+    }
+    
+    private Comment toEntity(CommentRequestDto commentRequestDto) {
+        return Comment.builder()
+                .contents(commentRequestDto.getContents())
+                .author(commentRequestDto.getAuthor())
+                .post(postService.findPost(commentRequestDto.getPostId()))
+                .build();
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
@@ -53,6 +53,13 @@ public class CommentController {
         Comment comment = commentService.findComment(commentId);
         return ResponseEntity.ok(toDto(comment));
     }
+
+    @DeleteMapping("/{commentId}")
+    @ResponseBody
+    public ResponseEntity<String> deleteComment(@PathVariable Long commentId) {
+        commentService.deleteComment(commentId);
+        return ResponseEntity.ok("댓글 삭제 성공");
+    }
     
     private Comment toEntity(CommentRequestDto commentRequestDto) {
         return Comment.builder()

--- a/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
@@ -3,17 +3,17 @@ package saramdle.blog.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import saramdle.blog.domain.Comment;
 import saramdle.blog.domain.CommentRequestDto;
+import saramdle.blog.domain.CommentResponseDto;
 import saramdle.blog.service.CommentService;
 import saramdle.blog.service.PostService;
 
 import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller
 @RequiredArgsConstructor
@@ -22,11 +22,20 @@ public class CommentController {
     private final CommentService commentService;
     private final PostService postService;
 
+    @GetMapping("/{postId}")
+    @ResponseBody
+    public ResponseEntity<List<CommentResponseDto>> getComment(@PathVariable Long postId) {
+        List<Comment> comments = commentService.findComments(postId);
+        List<CommentResponseDto> dtos = comments.stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(dtos);
+    }
+
     @PostMapping
     @ResponseBody
     public ResponseEntity<String> postComment(@RequestBody CommentRequestDto commentRequestDto) {
         Comment comment = toEntity(commentRequestDto);
-
         Long commentId = commentService.save(comment);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
@@ -42,6 +51,15 @@ public class CommentController {
                 .contents(commentRequestDto.getContents())
                 .author(commentRequestDto.getAuthor())
                 .post(postService.findPost(commentRequestDto.getPostId()))
+                .build();
+    }
+
+    private CommentResponseDto toDto(Comment comment) {
+        return CommentResponseDto.builder()
+                .id(comment.getId())
+                .contents(comment.getContents())
+                .author(comment.getAuthor())
+                .createdAt(comment.getCreatedAt())
                 .build();
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/CommentRequestDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/CommentRequestDto.java
@@ -1,0 +1,22 @@
+package saramdle.blog.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import saramdle.blog.service.PostService;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentRequestDto {
+    private String contents;
+    private String author;
+    private Long postId;
+
+    @Builder
+    private CommentRequestDto(String contents, String author, Long postId) {
+        this.contents = contents;
+        this.author = author;
+        this.postId = postId;
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/domain/CommentResponseDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/CommentResponseDto.java
@@ -1,0 +1,25 @@
+package saramdle.blog.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentResponseDto {
+    private Long id;
+    private String contents;
+    private String author;
+    private LocalDateTime createdAt;
+
+    @Builder
+    private CommentResponseDto(Long id, String contents, String author, LocalDateTime createdAt) {
+        this.id = id;
+        this.contents = contents;
+        this.author = author;
+        this.createdAt = createdAt;
+    }
+}


### PR DESCRIPTION
## PR Summary

- 클라이언트 요청에 따른 댓글 컨트롤러를 개발했습니다. 
- resolves #24 

## Changes

- 클라이언트 요청 데이터를 전달하기위한 CommentRequestDTO 생성
- 클라이언트 응답 데이터를 전달하기위한 CommentResponseDTO 생성
- 게시글 Post ID에 따른 댓글을 조회하는 컨트롤러 구현 -> getComment
- 댓글을 등록하는 컨트롤러 구현 -> postComment
- 댓글을 수정하는 컨트롤러 구현 -> updateComment
- 댓글을 삭제하는 컨트롤러 구현 -> deleteComment  

## Test Checklist
- 댓글 등록 테스트
<img width="883" alt="CommentPost" src="https://user-images.githubusercontent.com/56334151/227951685-92211fef-72fc-4149-9c77-ca36279af00a.png">

- 댓글 조회 테스트
<img width="883" alt="CommentGet" src="https://user-images.githubusercontent.com/56334151/227951792-b24716f0-c636-4cb1-b139-b58546108e0e.png">

- 댓글 수정 테스트
<img width="883" alt="CommentUpdate" src="https://user-images.githubusercontent.com/56334151/227951885-3ecfeab9-41d0-46e6-90bf-863636c4e530.png">

- 댓글 삭제 테스트
<img width="883" alt="CommentDelete" src="https://user-images.githubusercontent.com/56334151/227951951-d72e9878-57a5-4d50-ac37-4198e6894961.png">

- 댓글 요청에 대한 에러 발생 테스트
<img width="883" alt="CommentError" src="https://user-images.githubusercontent.com/56334151/227952141-e378e522-42e6-43a1-b0cb-94df79d5da8f.png">
