### PR TITLE
feat : API 예외 처리

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/domain/exception/BusinessException.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package saramdle.blog.domain.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    public BusinessException(String message, HttpStatus status) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/domain/exception/ExceptionControllerAdvice.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/exception/ExceptionControllerAdvice.java
@@ -25,4 +25,17 @@ public class ExceptionControllerAdvice {
 
         return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(exceptionResponse);
     }
+
+    @ExceptionHandler(BusinessException.class)
+    public final ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException exception, WebRequest request) {
+        log.error(exception.getMessage());
+
+        ExceptionResponse exceptionResponse = new ExceptionResponse(
+                LocalDateTime.now(),
+                exception.getMessage(),
+                request.getDescription(false)
+        );
+
+        return ResponseEntity.status(exception.getStatus()).body(exceptionResponse);
+    }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/exception/ExceptionControllerAdvice.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/exception/ExceptionControllerAdvice.java
@@ -1,0 +1,28 @@
+package saramdle.blog.domain.exception;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionControllerAdvice {
+
+    @ExceptionHandler(Exception.class)
+    public final ResponseEntity<ExceptionResponse> handleAllException(Exception exception, WebRequest request) {
+        log.error(exception.getMessage());
+
+        ExceptionResponse exceptionResponse = new ExceptionResponse(
+                LocalDateTime.now(),
+                exception.getMessage(),
+                request.getDescription(false)
+        );
+
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(exceptionResponse);
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/domain/exception/ExceptionResponse.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/exception/ExceptionResponse.java
@@ -1,0 +1,16 @@
+package saramdle.blog.domain.exception;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExceptionResponse {
+    private LocalDateTime time;
+    private String message;
+    private String description;
+}

--- a/back/blog/src/main/java/saramdle/blog/domain/exception/NotFoundException.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package saramdle.blog.domain.exception;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+public class NotFoundException extends BusinessException {
+    public NotFoundException(String message) {
+        super(message, NOT_FOUND);
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/service/CommentService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/CommentService.java
@@ -1,18 +1,18 @@
 package saramdle.blog.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import saramdle.blog.domain.Comment;
 import saramdle.blog.domain.CommentRepository;
-
-import java.util.List;
+import saramdle.blog.domain.exception.NotFoundException;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
 
-    private static final String NOT_FOUND_COMMENT = "해당 댓글을 찾을 수 없습니다.";
+    private static final String NOT_FOUND_COMMENT = "ID[%s] 댓글을 찾을 수 없습니다.";
     private final CommentRepository repository;
 
     @Transactional
@@ -22,7 +22,8 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public Comment findComment(Long id) {
-        return repository.findById(id).orElseThrow(() -> new IllegalStateException(NOT_FOUND_COMMENT));
+        return repository.findById(id)
+                .orElseThrow(() -> new NotFoundException(String.format(NOT_FOUND_COMMENT, id)));
     }
 
     @Transactional(readOnly = true)

--- a/back/blog/src/main/java/saramdle/blog/service/PostService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/PostService.java
@@ -6,12 +6,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import saramdle.blog.domain.Post;
 import saramdle.blog.domain.PostRepository;
+import saramdle.blog.domain.exception.NotFoundException;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
 
-    private static final String NOT_FOUND_POST = "해당 게시물을 찾을 수 없습니다.";
+    private static final String NOT_FOUND_POST = "ID[%s] 게시물을 찾을 수 없습니다.";
 
     private final PostRepository repository;
 
@@ -23,7 +24,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public Post findPost(Long postId) {
         return repository.findById(postId)
-                .orElseThrow(() -> new IllegalStateException(NOT_FOUND_POST));
+                .orElseThrow(() -> new NotFoundException(String.format(NOT_FOUND_POST, postId)));
     }
 
     @Transactional(readOnly = true)

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -1,15 +1,16 @@
 package saramdle.blog.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import saramdle.blog.domain.Comment;
 import saramdle.blog.domain.Post;
-
-import java.util.List;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import saramdle.blog.domain.exception.NotFoundException;
 
 @SpringBootTest
 class CommentServiceTest {
@@ -85,10 +86,8 @@ class CommentServiceTest {
 
         commentService.deleteComment(commentId);
 
-        try {
-            commentService.findComment(commentId);
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage()).isEqualTo("해당 댓글을 찾을 수 없습니다.");
-        }
+        assertThatThrownBy(() -> commentService.findComment(commentId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("댓글을 찾을 수 없습니다.");
     }
 }

--- a/back/blog/src/test/java/saramdle/blog/service/PostServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/PostServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import saramdle.blog.domain.Post;
 import saramdle.blog.domain.PostRepository;
+import saramdle.blog.domain.exception.NotFoundException;
 
 @Transactional
 @SpringBootTest
@@ -45,7 +46,7 @@ class PostServiceTest {
     @DisplayName("존재하지 않은 게시물을 조회할 경우 예외가 발생합니다.")
     void findPostFail() {
         assertThatThrownBy(() -> postService.findPost(100L))
-                .isInstanceOf(IllegalStateException.class);
+                .isInstanceOf(NotFoundException.class);
     }
 
     @Test


### PR DESCRIPTION
## PR Summary

- API 호출 시 예외 발생 상황에 대하여 적절한 HttpStatus와 Message를 전달하도록 예외처리를 진행하였습니다.

## Changes

- 스프링 AOP 기술을 활용하여 RestController에서 발생하는 모든 예외를 처리하는 RestControllerAdvice를 생성하였습니다.
- 모든 커스텀 예외의 상위 계층으로 `BusinessException` 예외 클래스를 생성해 ExceptionHandler로 추가해주었습니다.
- 엔티티를 찾을 수 없는 경우 404 예외를 보내는 `NotFoundException` 예외 클래스를 생성했습니다.
- 통일된 예외 응답을 주기 위해 `ExceptionResponse` 예외 응답 객체를 생성했습니다. 

## Test Checklist
- [x] 게시물 조회 예외 발생 테스트
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/91456818/228220328-07a5f0af-12a3-47c5-bd92-e4db881effa1.png">

