### PR TITLE
feat : 댓글들을 화면에 보여주는 UI 구현

### DIFF
--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
         <div className='flex h-screen flex-col'>
           <Navbar />
           <div className='flex-grow'>{children}</div>
-          <Footer />
+          {/* <Footer /> */}
         </div>
       </body>
     </html>

--- a/front/app/posts/[postId]/CommentInput.tsx
+++ b/front/app/posts/[postId]/CommentInput.tsx
@@ -16,7 +16,7 @@ export default function CommentInput() {
           name='comment'
           id='comment'
           rows={3}
-          className='w-full resize-none rounded-md bg-primary/5 p-3'
+          className='h-[100px] w-full resize-none rounded-md bg-primary/5 p-3'
           placeholder='댓글을 남겨주세요'
           value={commentInput}
           onChange={handleChange}

--- a/front/app/posts/[postId]/Comments.tsx
+++ b/front/app/posts/[postId]/Comments.tsx
@@ -1,0 +1,37 @@
+export const fetchCache = "force-no-store";
+
+type Comment = {
+  id: number;
+  author: string;
+  contents: string;
+  post: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+async function getComments() {
+  const res = await fetch(`http://localhost:4000/comments`);
+  if (!res.ok) {
+    throw new Error("Failed to fetch data");
+  }
+  return res.json();
+}
+
+export default async function Comments({ postId }: { postId: number }) {
+  const comments = await getComments();
+  const selectedComments = comments.filter(
+    (comment: Comment) => comment.post == postId
+  );
+
+  return (
+    <div>
+      {selectedComments.map((comment: Comment) => (
+        <div key={comment.id}>
+          <div>{comment.contents}</div>
+          <div>{comment.author}</div>
+          <div>{comment.createdAt}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/front/app/posts/[postId]/Comments.tsx
+++ b/front/app/posts/[postId]/Comments.tsx
@@ -1,3 +1,6 @@
+import moment from "moment";
+import { AiOutlineDelete, AiOutlineEdit } from "react-icons/ai";
+
 export const fetchCache = "force-no-store";
 
 type Comment = {
@@ -24,12 +27,26 @@ export default async function Comments({ postId }: { postId: number }) {
   );
 
   return (
-    <div>
+    <div className='my-10 flex flex-col gap-4 shadow-sm'>
       {selectedComments.map((comment: Comment) => (
-        <div key={comment.id}>
-          <div>{comment.contents}</div>
-          <div>{comment.author}</div>
-          <div>{comment.createdAt}</div>
+        <div key={comment.id} className='flex justify-between bg-white p-3'>
+          <div>
+            <div className='text-sm font-bold'>{comment.author}</div>
+            <div className='py-2 text-xl'>{comment.contents}</div>
+            <div className='text-sx text-gray-400'>
+              {moment(moment(comment.createdAt).format("YYYY-MM-DD")).fromNow()}
+            </div>
+          </div>
+          <div className='text- flex gap-2 text-gray-500'>
+            <AiOutlineEdit
+              size={20}
+              className='cursor-pointer hover:scale-125 hover:text-primary'
+            />
+            <AiOutlineDelete
+              size={20}
+              className='cursor-pointer hover:scale-125 hover:text-primary'
+            />
+          </div>
         </div>
       ))}
     </div>

--- a/front/app/posts/[postId]/Comments.tsx
+++ b/front/app/posts/[postId]/Comments.tsx
@@ -27,12 +27,15 @@ export default async function Comments({ postId }: { postId: number }) {
   );
 
   return (
-    <div className='my-10 flex flex-col gap-4 shadow-sm'>
+    <div className='my-10 flex  flex-col gap-4 shadow-sm'>
       {selectedComments.map((comment: Comment) => (
-        <div key={comment.id} className='flex justify-between bg-white p-3'>
+        <div
+          key={comment.id}
+          className='flex h-[100px] justify-between rounded-md bg-white p-3'
+        >
           <div>
             <div className='text-sm font-bold'>{comment.author}</div>
-            <div className='py-2 text-xl'>{comment.contents}</div>
+            <div className='py-1 text-xl'>{comment.contents}</div>
             <div className='text-sx text-gray-400'>
               {moment(moment(comment.createdAt).format("YYYY-MM-DD")).fromNow()}
             </div>

--- a/front/app/posts/[postId]/page.tsx
+++ b/front/app/posts/[postId]/page.tsx
@@ -1,11 +1,8 @@
 import Container from "@/app/components/Container";
 import { Metadata } from "next";
 import Image from "next/image";
-<<<<<<< HEAD
 import CommentInput from "./CommentInput";
-=======
 import Comments from "./Comments";
->>>>>>> 0074db2 (feat : 코멘트 데이터 server side fetching)
 
 async function getPost(id: number) {
   const res = await fetch(`http://localhost:4000/posts/${id}`, {
@@ -52,12 +49,9 @@ export default async function Page({
       />
       <p>{post?.author}</p>
       <p>{post?.createdAt}</p>
-<<<<<<< HEAD
       <CommentInput />
-=======
       {/* @ts-expect-error Server Component */}
       <Comments postId={postId} />
->>>>>>> 0074db2 (feat : 코멘트 데이터 server side fetching)
     </Container>
   );
 }

--- a/front/app/posts/[postId]/page.tsx
+++ b/front/app/posts/[postId]/page.tsx
@@ -1,7 +1,11 @@
 import Container from "@/app/components/Container";
 import { Metadata } from "next";
 import Image from "next/image";
+<<<<<<< HEAD
 import CommentInput from "./CommentInput";
+=======
+import Comments from "./Comments";
+>>>>>>> 0074db2 (feat : 코멘트 데이터 server side fetching)
 
 async function getPost(id: number) {
   const res = await fetch(`http://localhost:4000/posts/${id}`, {
@@ -48,7 +52,12 @@ export default async function Page({
       />
       <p>{post?.author}</p>
       <p>{post?.createdAt}</p>
+<<<<<<< HEAD
       <CommentInput />
+=======
+      {/* @ts-expect-error Server Component */}
+      <Comments postId={postId} />
+>>>>>>> 0074db2 (feat : 코멘트 데이터 server side fetching)
     </Container>
   );
 }

--- a/front/db.json
+++ b/front/db.json
@@ -69,7 +69,7 @@
       "id": 1,
       "author": "우정",
       "contents": "testing message!!11111111111",
-      "post": 7,
+      "post": 6,
       "createdAt": "2023-03-01 11:47:49.164",
       "updatedAt": "2023-03-01 11:48:09.165"
     },
@@ -77,7 +77,7 @@
       "id": 2,
       "author": "우정",
       "contents": "testing message!!222222222222",
-      "post": 7,
+      "post": 6,
       "createdAt": "2023-03-01 11:47:49.164",
       "updatedAt": "2023-03-01 11:48:09.165"
     },
@@ -85,7 +85,7 @@
       "id": 3,
       "author": "우정",
       "contents": "testing message!!333333333333",
-      "post": 7,
+      "post": 6,
       "createdAt": "2023-03-01 11:47:49.164",
       "updatedAt": "2023-03-01 11:48:09.165"
     },
@@ -93,7 +93,7 @@
       "id": 4,
       "author": "정우",
       "contents": "testing message!!4444",
-      "post": 6,
+      "post": 5,
       "createdAt": "2023-03-01 11:47:49.164",
       "updatedAt": "2023-03-01 11:48:09.165"
     }

--- a/front/db.json
+++ b/front/db.json
@@ -63,5 +63,39 @@
       "updatedAt": "2023-03-27T23:23:21.910Z",
       "id": 7
     }
+  ],
+  "comments": [
+    {
+      "id": 1,
+      "author": "우정",
+      "contents": "testing message!!11111111111",
+      "post": 7,
+      "createdAt": "2023-03-01 11:47:49.164",
+      "updatedAt": "2023-03-01 11:48:09.165"
+    },
+    {
+      "id": 2,
+      "author": "우정",
+      "contents": "testing message!!222222222222",
+      "post": 7,
+      "createdAt": "2023-03-01 11:47:49.164",
+      "updatedAt": "2023-03-01 11:48:09.165"
+    },
+    {
+      "id": 3,
+      "author": "우정",
+      "contents": "testing message!!333333333333",
+      "post": 7,
+      "createdAt": "2023-03-01 11:47:49.164",
+      "updatedAt": "2023-03-01 11:48:09.165"
+    },
+    {
+      "id": 4,
+      "author": "정우",
+      "contents": "testing message!!4444",
+      "post": 6,
+      "createdAt": "2023-03-01 11:47:49.164",
+      "updatedAt": "2023-03-01 11:48:09.165"
+    }
   ]
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -16,7 +16,7 @@
         "daisyui": "^2.51.3",
         "eslint": "8.35.0",
         "eslint-config-next": "13.2.3",
-        "json-server": "^0.17.2",
+        "json-server": "^0.17.3",
         "moment": "^2.29.4",
         "next": "13.2.3",
         "react": "18.2.0",
@@ -3398,9 +3398,9 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-server": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/json-server/-/json-server-0.17.2.tgz",
-      "integrity": "sha512-PKmTFfiUduibc9QyieY9PDiSG4CttFpqpVkwTvWWbGQaah4Id/gKqn5er4dnynUw4GVdjAzGKjSbBuVIlXM6mw==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/json-server/-/json-server-0.17.3.tgz",
+      "integrity": "sha512-LDNOvleTv3rPAcefzXZpXMDZshV0FtSzWo8ZjnTOhKm4OCiUvsYGrGrfz4iHXIFd+UbRgFHm6gcOHI/BSZ/3fw==",
       "dependencies": {
         "body-parser": "^1.19.0",
         "chalk": "^4.1.2",
@@ -8059,9 +8059,9 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-server": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/json-server/-/json-server-0.17.2.tgz",
-      "integrity": "sha512-PKmTFfiUduibc9QyieY9PDiSG4CttFpqpVkwTvWWbGQaah4Id/gKqn5er4dnynUw4GVdjAzGKjSbBuVIlXM6mw==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/json-server/-/json-server-0.17.3.tgz",
+      "integrity": "sha512-LDNOvleTv3rPAcefzXZpXMDZshV0FtSzWo8ZjnTOhKm4OCiUvsYGrGrfz4iHXIFd+UbRgFHm6gcOHI/BSZ/3fw==",
       "requires": {
         "body-parser": "^1.19.0",
         "chalk": "^4.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "daisyui": "^2.51.3",
     "eslint": "8.35.0",
     "eslint-config-next": "13.2.3",
-    "json-server": "^0.17.2",
+    "json-server": "^0.17.3",
     "moment": "^2.29.4",
     "next": "13.2.3",
     "react": "18.2.0",


### PR DESCRIPTION
## PR Summary

- 개별 post에 속한 댓글들을 화면에 보여줌
- 아직 백엔드와 연동되지 않은 관계로 일단 모든 댓글들을 fetching 후 postID에 따라서 filtering하여 화면에 표시
> - 계획 : /comments/{postId} GET요청하여 backend에서 postId에 해당하는 댓글만을 전송함
> - 임시 : /comments GET요청하여 모든 댓글을 fetching한 후 frontend에서 postId에 해당하는 댓글만을 보여줌
- resolves #35

## Changes

- 댓글 입력창과 댓글창 UI를 통합하였으며 디자인 일관성을 위해 높이, border-radius등 CSS 수정
- footer의 위치가 맞지 않는 문제가 발생하여 잠시 비활성화
- jason-server 라이브러리 업데이트

## Reference
![image](https://user-images.githubusercontent.com/91456818/228711518-8da2d61d-539a-4fc2-85d2-0af4abe742dd.png)
