### PR TITLE
refactor : 기존 author 필드를 회원 엔티티로 변경 및 연관관계 적용

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
@@ -1,19 +1,25 @@
 package saramdle.blog.controller;
 
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import saramdle.blog.domain.Comment;
 import saramdle.blog.domain.CommentRequestDto;
 import saramdle.blog.domain.CommentResponseDto;
 import saramdle.blog.service.CommentService;
 import saramdle.blog.service.PostService;
-
-import java.net.URI;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Controller
 @RequiredArgsConstructor
@@ -64,7 +70,7 @@ public class CommentController {
     private Comment toEntity(CommentRequestDto commentRequestDto) {
         return Comment.builder()
                 .contents(commentRequestDto.getContents())
-                .author(commentRequestDto.getAuthor())
+                .user(commentRequestDto.getUser())
                 .post(postService.findPost(commentRequestDto.getPostId()))
                 .build();
     }
@@ -73,7 +79,7 @@ public class CommentController {
         return CommentResponseDto.builder()
                 .id(comment.getId())
                 .contents(comment.getContents())
-                .author(comment.getAuthor())
+                .user(comment.getUser())
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/back/blog/src/main/java/saramdle/blog/controller/PostController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/PostController.java
@@ -77,7 +77,7 @@ public class PostController {
                 .id(post.getId())
                 .title(post.getTitle())
                 .contents(post.getContents())
-                .author(post.getAuthor())
+                .user(post.getUser())
                 .imgUrl(post.getImgUrl())
                 .createdAt(post.getCreatedAt())
                 .build();
@@ -87,7 +87,7 @@ public class PostController {
         return Post.builder()
                 .title(postRequestDto.getTitle())
                 .contents(postRequestDto.getContents())
-                .author(postRequestDto.getAuthor())
+                .user(postRequestDto.getUser())
                 .imgUrl(postRequestDto.getImgUrl())
                 .build();
     }

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -26,7 +26,7 @@ public class Comment extends BaseTimeEntity {
 
     private String contents;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/back/blog/src/main/java/saramdle/blog/domain/Comment.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Comment.java
@@ -2,6 +2,7 @@ package saramdle.blog.domain;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -29,14 +30,16 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    private String author;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @Builder
-    private Comment(Long id, String contents, Post post, String author) {
+    private Comment(Long id, String contents, Post post, User user) {
         this.id = id;
         this.contents = contents;
         this.post = post;
-        this.author = author;
+        this.user = user;
     }
 
     public void update(String contents) {

--- a/back/blog/src/main/java/saramdle/blog/domain/CommentRequestDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/CommentRequestDto.java
@@ -4,19 +4,18 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import saramdle.blog.service.PostService;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentRequestDto {
     private String contents;
-    private String author;
+    private User user;
     private Long postId;
 
     @Builder
-    private CommentRequestDto(String contents, String author, Long postId) {
+    private CommentRequestDto(String contents, User user, Long postId) {
         this.contents = contents;
-        this.author = author;
+        this.user = user;
         this.postId = postId;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/CommentResponseDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/CommentResponseDto.java
@@ -1,25 +1,24 @@
 package saramdle.blog.domain;
 
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentResponseDto {
     private Long id;
     private String contents;
-    private String author;
+    private User user;
     private LocalDateTime createdAt;
 
     @Builder
-    private CommentResponseDto(Long id, String contents, String author, LocalDateTime createdAt) {
+    private CommentResponseDto(Long id, String contents, User user, LocalDateTime createdAt) {
         this.id = id;
         this.contents = contents;
-        this.author = author;
+        this.user = user;
         this.createdAt = createdAt;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/Post.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Post.java
@@ -2,9 +2,12 @@ package saramdle.blog.domain;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,21 +28,23 @@ public class Post extends BaseTimeEntity {
 
     private String contents;
 
-    private String author;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     private String imgUrl;
 
     @Builder
-    private Post(String title, String contents, String author, String imgUrl) {
+    private Post(String title, String contents, User user, String imgUrl) {
         this.title = title;
         this.contents = contents;
-        this.author = author;
+        this.user = user;
         this.imgUrl = imgUrl;
     }
 
-    public void update(String title, String author, String contents) {
+    public void update(String title, User user, String contents) {
         this.title = title;
-        this.author = author;
+        this.user = user;
         this.contents = contents;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/Post.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/Post.java
@@ -42,9 +42,9 @@ public class Post extends BaseTimeEntity {
         this.imgUrl = imgUrl;
     }
 
-    public void update(String title, User user, String contents) {
+    public void update(String title, String contents, String imgUrl) {
         this.title = title;
-        this.user = user;
         this.contents = contents;
+        this.imgUrl = imgUrl;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/PostRequestDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/PostRequestDto.java
@@ -10,14 +10,14 @@ import lombok.NoArgsConstructor;
 public class PostRequestDto {
     private String title;
     private String contents;
-    private String author;
+    private User user;
     private String imgUrl;
 
     @Builder
-    private PostRequestDto(String title, String contents, String author, String imgUrl) {
+    private PostRequestDto(String title, String contents, User user, String imgUrl) {
         this.title = title;
         this.contents = contents;
-        this.author = author;
+        this.user = user;
         this.imgUrl = imgUrl;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/PostResponseDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/PostResponseDto.java
@@ -12,17 +12,17 @@ public class PostResponseDto {
     private Long id;
     private String title;
     private String contents;
-    private String author;
+    private User user;
     private String imgUrl;
     private LocalDateTime createdAt;
 
     @Builder
-    private PostResponseDto(Long id, String title, String contents, String author,
+    private PostResponseDto(Long id, String title, String contents, User user,
                             String imgUrl, LocalDateTime createdAt) {
         this.id = id;
         this.title = title;
         this.contents = contents;
-        this.author = author;
+        this.user = user;
         this.imgUrl = imgUrl;
         this.createdAt = createdAt;
     }

--- a/back/blog/src/main/java/saramdle/blog/service/PostService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/PostService.java
@@ -35,7 +35,7 @@ public class PostService {
     @Transactional
     public Long update(Long postId, Post updateParam) {
         Post post = findPost(postId);
-        post.update(updateParam.getTitle(), updateParam.getUser(), updateParam.getContents());
+        post.update(updateParam.getTitle(), updateParam.getContents(), updateParam.getImgUrl());
         return postId;
     }
 

--- a/back/blog/src/main/java/saramdle/blog/service/PostService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/PostService.java
@@ -35,7 +35,7 @@ public class PostService {
     @Transactional
     public Long update(Long postId, Post updateParam) {
         Post post = findPost(postId);
-        post.update(updateParam.getTitle(), updateParam.getAuthor(), updateParam.getContents());
+        post.update(updateParam.getTitle(), updateParam.getUser(), updateParam.getContents());
         return postId;
     }
 

--- a/back/blog/src/main/resources/application.yml
+++ b/back/blog/src/main/resources/application.yml
@@ -9,14 +9,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
 
   profiles:
     include: oauth
 
 logging:
-  level:
-    org.hibernate.type.descriptor.sql: trace
+  level.org.hibernate:
+    SQL: debug
+    type.descriptor.sql.BasicBinder: trace

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -7,10 +7,12 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 import saramdle.blog.domain.Comment;
 import saramdle.blog.domain.Post;
 import saramdle.blog.domain.exception.NotFoundException;
 
+@Transactional
 @SpringBootTest
 class CommentServiceTest {
 

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.util.List;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,8 +20,6 @@ class CommentServiceTest {
     @Autowired
     PostService postService;
 
-
-    @DisplayName("댓글 저장")
     @Test
     void save() {
         Post post = Post.builder().build();
@@ -33,6 +30,7 @@ class CommentServiceTest {
 
         assertThat(saveId).isEqualTo(comment.getId());
     }
+
     @Test
     void findComment() {
         Post post = Post.builder().build();
@@ -52,15 +50,15 @@ class CommentServiceTest {
         postService.save(post);
 
         Comment comment = Comment.builder().post(post).build();
-
         commentService.save(comment);
 
         List<Comment> foundComments = commentService.findComments(post.getId());
+
         assertThat(foundComments.size()).isEqualTo(1);
     }
 
     @Test
-    void updateComments() {
+    void updateComment() {
         Post post = Post.builder().build();
         postService.save(post);
 
@@ -68,11 +66,9 @@ class CommentServiceTest {
         Long commentId = commentService.save(comment);
 
         Comment newComment = Comment.builder().contents("Hello World").build();
-
         Long updatedCommentId = commentService.updateComment(commentId, newComment);
 
         Comment result = commentService.findComment(updatedCommentId);
-
         assertThat(result.getContents()).isEqualTo("Hello World");
     }
 

--- a/back/blog/src/test/java/saramdle/blog/service/PostServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/PostServiceTest.java
@@ -65,17 +65,24 @@ class PostServiceTest {
     @Test
     @DisplayName("게시물을 수정합니다.")
     void update() {
-        Post post = Post.builder().title("제목1").author("작성자1").contents("본문1").build();
-        Post savedPost = postRepository.save(post);
-        Long postId = savedPost.getId();
+        Post post = Post.builder()
+                .title("제목1")
+                .contents("본문1")
+                .imgUrl("https://t1.daumcdn.net/cfile/tistory/993F75355A692ABD32")
+                .build();
+        Long postId = postRepository.save(post).getId();
 
-        Post updateParam = Post.builder().title("제목2").author("작성자2").contents("본문2").build();
+        Post updateParam = Post.builder()
+                .title("제목2")
+                .contents("본문2")
+                .imgUrl("https://img.siksinhot.com/article/1638761259231391.jpg")
+                .build();
         postService.update(postId, updateParam);
 
         Post findPost = postRepository.findById(postId).orElseThrow();
         assertThat(findPost.getTitle()).isEqualTo(updateParam.getTitle());
-        assertThat(findPost.getAuthor()).isEqualTo(updateParam.getAuthor());
         assertThat(findPost.getContents()).isEqualTo(updateParam.getContents());
+        assertThat(findPost.getImgUrl()).isEqualTo(updateParam.getImgUrl());
     }
 
     @Test

--- a/back/blog/src/test/resources/application.yml
+++ b/back/blog/src/test/resources/application.yml
@@ -1,3 +1,4 @@
 spring:
   profiles:
     active: "test"
+    include: oauth


### PR DESCRIPTION
## PR Summary

- `Post-User`, `Comment-User` 간 연관관계를 추가해 기존에 사용하던 String 타입의 author 필드를 User 타입의 user로 변경했습니다.

## Changes
- `Post-User`와 `Comment-User` 간 `@ManyToOne` 단방향 매핑 적용
- 기존 `Post`, `Comment` 엔티티의 author 필드명이 user로 변경됨에 따라 오류가 발생하는 코드들을 일괄 수정
- 게시물 수정시 작성자가 변경되는 일은 없을 것으로 판단해 user 파라미터를 제거하고, 이미지 변경이 누락되어 있어 imgUrl 파라미터를 추가
- `Comment-Post` 간 연관관계에서 fetchType을 즉시로딩(EAGER)을 지연로딩(LAZY)로 변경
- 각각의 테스트가 서로 영향을 미치지 않도록 `CommentServiceTest` 클래스에 `@Transactional` 추가
- 테스트 실행시 oauth 설정 정보가 없다는 원인으로 오류가 발생해 test 패키지에도 application-auth.yml 파일 추가
```
⛔️ 발생 오류
Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration': Unsatisfied dependency expressed through method 'setFilterChains' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'securityFilterChain' defined in class path resource [saramdle/blog/config/auth/SecurityConfig.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.security.web.SecurityFilterChain]: Factory method 'securityFilterChain' threw exception; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.springframework.security.oauth2.client.registration.ClientRegistrationRepository' available
```