### PR TITLE
feat : 이미지 첨부 기능 구현

### DIFF
--- a/front/app/write/page.tsx
+++ b/front/app/write/page.tsx
@@ -23,6 +23,38 @@ export default function Write() {
   const [contentsInput, setContentsInput] = useState<string>("");
   const [title, setTitle] = useState<string>("");
 
+  const [value, setValue] = useState('');
+  const quillRef = useRef(ReactQuill);
+
+  const imageHandler = () => {
+    const input = document.createElement('input')
+
+    input.setAttribute('type','file');
+    input.setAttribute('accept','image/*');
+    input.click();
+
+    input.addEventListener('change', async () => {
+      if (input.files != null){
+      const file = input.files[0];
+      const formData = new FormData();
+      formData.append('file',file);
+
+       try{ 
+        const response = await fetch("http://localhost:8080/image", {
+          method: "POST",
+          body: formData, 
+        }).then(res => res.text());
+        const imgUrl = response;
+       
+        const editor = quillRef.current.getEditor();
+        const range = editor.getSelection();
+        editor.insertEmbed(range.index, 'image', imgUrl);
+      }catch(error){
+        alert('이미지 추가를 실패했습니다.')
+      }}
+    });
+  };
+
   const modules = useMemo(
     () => ({
       toolbar: {
@@ -35,7 +67,7 @@ export default function Write() {
         ],
         handlers: {
           //이미지 업로드 함수 필요
-          // image: imageHandler,
+          image: imageHandler,
         },
       },
     }),
@@ -95,6 +127,7 @@ export default function Write() {
         <div>
           {mounted && (
             <ReactQuill
+              ref={quillRef}
               theme='snow'
               value={contentsInput}
               onChange={setContentsInput}


### PR DESCRIPTION
## PR Summary

- 이미지 버튼을 눌러서 이미지를 선택해주면 이미지가 서버에 업로드 시킨 후 반환 받는 이미지 url을 활용해 이미지 태그를 만들어 글에 첨부합니다
- resolves #55 

## Changes

- ImageHandler 추가

## To Reviewers
![image](https://user-images.githubusercontent.com/56334151/232357054-fe3b7400-b982-46a6-9850-867944a7d9a2.png)
정상적으로 첨부되어서 게시글 등록 확인했습니다.
