### PR TITLE
feat : footer 컴포넌트 생성 및 적용

### DIFF
--- a/front/app/components/Footer.tsx
+++ b/front/app/components/Footer.tsx
@@ -10,14 +10,17 @@ export default function Footer() {
     return <></>;
   }
   return (
-    <footer className='bg-slate-900 text-white'>
+    <footer className='mt-8 bg-gray-400 text-white'>
       <Container>
-        <Link
-          href='/'
-          className='m-1 block w-60 border-4 border-white p-2 text-center text-sm font-bold uppercase text-white transition-colors duration-300 ease-in-out'
-        >
-          flavour 4 Favor
-        </Link>
+        <div className='flex items-center justify-between p-2 font-bold'>
+          <Link
+            href='/'
+            className='block w-48 border-4 border-white p-2 text-center text-sm font-bold uppercase'
+          >
+            flavour 4 Favor
+          </Link>
+          <p>Copyright © 2023 - Zolin Friendship</p>
+        </div>
       </Container>
     </footer>
   );

--- a/front/app/components/Footer.tsx
+++ b/front/app/components/Footer.tsx
@@ -1,9 +1,24 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import Container from "./Container";
 
 export default function Footer() {
+  const path = usePathname();
+  if (path === "/write") {
+    return <></>;
+  }
   return (
-    <footer className='bg-slate-300'>
-      <Container>4조 블로그</Container>
+    <footer className='bg-slate-900 text-white'>
+      <Container>
+        <Link
+          href='/'
+          className='m-1 block w-60 border-4 border-white p-2 text-center text-sm font-bold uppercase text-white transition-colors duration-300 ease-in-out'
+        >
+          flavour 4 Favor
+        </Link>
+      </Container>
     </footer>
   );
 }

--- a/front/app/components/Navbar.tsx
+++ b/front/app/components/Navbar.tsx
@@ -6,6 +6,7 @@ import Container from "./Container";
 import Link from "next/link";
 import { NAV_ITEMS } from "@/constants/navItems";
 import { AiOutlineClose, AiOutlineMenu } from "react-icons/ai";
+import { usePathname } from "next/navigation";
 
 export default function Navbar() {
   const [isLoggedin, setIsLoggedin] = useState<boolean>(false);
@@ -19,6 +20,11 @@ export default function Navbar() {
     //to prevent scrolling when drawer is open
     document.body.classList.toggle("drawer-open");
   };
+
+  const path = usePathname();
+  if (path === "/write") {
+    return <></>;
+  }
 
   return (
     <header className='select-none p-2'>

--- a/front/app/globals.css
+++ b/front/app/globals.css
@@ -2,13 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-html::-webkit-scrollbar {
-  display: none;
-}
-html {
-  scrollbar-width: none;
-}
-
 :root {
   background: #eee;
 }

--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
           <div className='flex h-screen flex-col'>
             <Navbar />
             <div className='flex-grow'>{children}</div>
-            {/* <Footer /> */}
+            <Footer />
           </div>
         </TanStackWrapper>
       </body>

--- a/front/app/posts/AddFloating.tsx
+++ b/front/app/posts/AddFloating.tsx
@@ -6,7 +6,7 @@ import { IoMdAdd } from "react-icons/io";
 export default function AddFloating() {
   return (
     <Link href='/write'>
-      <div className='fixed right-20 bottom-20 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full bg-primary/80 text-5xl font-bold text-white shadow-2xl hover:opacity-75'>
+      <div className='fixed right-20 bottom-10 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full bg-primary/80 text-5xl font-bold text-white shadow-2xl hover:opacity-75'>
         <IoMdAdd />
       </div>
     </Link>

--- a/front/app/write/page.tsx
+++ b/front/app/write/page.tsx
@@ -110,7 +110,7 @@ export default function Write() {
   return (
     <div className='flex'>
       <form
-        className='flex flex-1 flex-col gap-5 p-4'
+        className='flex h-screen flex-1 flex-col gap-5 p-4'
         onSubmit={onSubmitPreventDefault}
       >
         <div className='flex items-center'>
@@ -122,17 +122,16 @@ export default function Write() {
             onChange={(e) => setTitle(e.target.value)}
           />
         </div>
-
-        <div>
+        <div className='flex-grow'>
           {mounted && (
             <ReactQuill
               ref={quillRef}
               theme='snow'
               value={contentsInput}
               onChange={setContentsInput}
-              className='h-[550px]'
               modules={modules}
               placeholder='배부르지 않으면 세상 모든 것이 어렵다...'
+              className='h-full'
             />
           )}
         </div>


### PR DESCRIPTION
## PR Summary

- footer 컴포넌트 작업
- resolves #57 

## Changes

- 웹사이트 하단에 footer 생성
<img width="1267" alt="image" src="https://user-images.githubusercontent.com/87072568/232657282-410be685-2160-4e7e-b6d3-287a64dad5f5.png">
-"/write" 페이지에 header, footer 보이지 않도록 조정
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/87072568/232657137-3fabf4c6-65bf-4a39-9867-d99310b34a81.png">
