### PR TITLE
feat : 시큐리티에서 사용되는 인증된 사용자 객체를 커스터마이징

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/config/auth/CustomOAuth2UserService.java
+++ b/back/blog/src/main/java/saramdle/blog/config/auth/CustomOAuth2UserService.java
@@ -10,8 +10,8 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import saramdle.blog.config.auth.dto.LoginUser;
 import saramdle.blog.config.auth.dto.OAuthAttributes;
-import saramdle.blog.config.auth.dto.SessionUser;
 import saramdle.blog.domain.User;
 import saramdle.blog.domain.UserRepository;
 
@@ -35,7 +35,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes()); // OAuth 서비스의 유저 정보들
         User user = saveOrUpdate(attributes);
 
-        return new UserPrinciple(new SessionUser(user),
+        return new CustomUserPrinciple(new LoginUser(user),
                 Collections.singleton(new SimpleGrantedAuthority(user.getRole().toString())),
                 attributes.getAttributes()
         );

--- a/back/blog/src/main/java/saramdle/blog/config/auth/CustomOAuth2UserService.java
+++ b/back/blog/src/main/java/saramdle/blog/config/auth/CustomOAuth2UserService.java
@@ -1,16 +1,13 @@
 package saramdle.blog.config.auth;
 
-import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-import saramdle.blog.config.auth.dto.LoginUser;
 import saramdle.blog.config.auth.dto.OAuthAttributes;
 import saramdle.blog.domain.User;
 import saramdle.blog.domain.UserRepository;
@@ -35,10 +32,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes()); // OAuth 서비스의 유저 정보들
         User user = saveOrUpdate(attributes);
 
-        return new CustomUserPrinciple(new LoginUser(user),
-                Collections.singleton(new SimpleGrantedAuthority(user.getRole().toString())),
-                attributes.getAttributes()
-        );
+        return new CustomUserPrinciple(user, attributes);
     }
 
     private User saveOrUpdate(OAuthAttributes attributes) {

--- a/back/blog/src/main/java/saramdle/blog/config/auth/CustomOAuth2UserService.java
+++ b/back/blog/src/main/java/saramdle/blog/config/auth/CustomOAuth2UserService.java
@@ -1,9 +1,6 @@
 package saramdle.blog.config.auth;
 
-import static saramdle.blog.config.auth.SessionConst.LOGIN_USER;
-
 import java.util.Collections;
-import javax.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -11,7 +8,6 @@ import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserServ
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import saramdle.blog.config.auth.dto.OAuthAttributes;
@@ -25,7 +21,6 @@ import saramdle.blog.domain.UserRepository;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final UserRepository userRepository;
-    private final HttpSession httpSession; // 로그인 정보를 저장할 세션
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -40,12 +35,9 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes()); // OAuth 서비스의 유저 정보들
         User user = saveOrUpdate(attributes);
 
-        httpSession.setAttribute(LOGIN_USER, new SessionUser(user));
-
-        return new DefaultOAuth2User(
+        return new UserPrinciple(new SessionUser(user),
                 Collections.singleton(new SimpleGrantedAuthority(user.getRole().toString())),
-                attributes.getAttributes(),
-                attributes.getNameAttributeKey()
+                attributes.getAttributes()
         );
     }
 

--- a/back/blog/src/main/java/saramdle/blog/config/auth/CustomUserPrinciple.java
+++ b/back/blog/src/main/java/saramdle/blog/config/auth/CustomUserPrinciple.java
@@ -43,6 +43,10 @@ public class UserPrinciple implements OAuth2User, Serializable {
         return user.getEmail();
     }
 
+    public SessionUser getUser() {
+        return user;
+    }
+
     private Set<GrantedAuthority> sortAuthorities(Collection<? extends GrantedAuthority> authorities) {
         SortedSet<GrantedAuthority> sortedAuthorities = new TreeSet<>(
                 Comparator.comparing(GrantedAuthority::getAuthority));

--- a/back/blog/src/main/java/saramdle/blog/config/auth/CustomUserPrinciple.java
+++ b/back/blog/src/main/java/saramdle/blog/config/auth/CustomUserPrinciple.java
@@ -12,16 +12,16 @@ import java.util.TreeSet;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import saramdle.blog.config.auth.dto.SessionUser;
+import saramdle.blog.config.auth.dto.LoginUser;
 
-public class UserPrinciple implements OAuth2User, Serializable {
+public class CustomUserPrinciple implements OAuth2User, Serializable {
 
-    private SessionUser user;
+    private LoginUser loginUser;
     private Set<GrantedAuthority> authorities;
     private Map<String, Object> oAuthAttributes;
 
-    public UserPrinciple(SessionUser user, Collection<? extends GrantedAuthority> authorities, Map<String, Object> oAuthAttributes) {
-        this.user = user;
+    public CustomUserPrinciple(LoginUser loginUser, Collection<? extends GrantedAuthority> authorities, Map<String, Object> oAuthAttributes) {
+        this.loginUser = loginUser;
         this.authorities = (authorities != null)
                 ? Collections.unmodifiableSet(new LinkedHashSet<>(this.sortAuthorities(authorities)))
                 : Collections.unmodifiableSet(new LinkedHashSet<>(AuthorityUtils.NO_AUTHORITIES));
@@ -40,11 +40,11 @@ public class UserPrinciple implements OAuth2User, Serializable {
 
     @Override
     public String getName() {
-        return user.getEmail();
+        return loginUser.getEmail();
     }
 
-    public SessionUser getUser() {
-        return user;
+    public LoginUser getLoginUser() {
+        return loginUser;
     }
 
     private Set<GrantedAuthority> sortAuthorities(Collection<? extends GrantedAuthority> authorities) {

--- a/back/blog/src/main/java/saramdle/blog/config/auth/CustomUserPrinciple.java
+++ b/back/blog/src/main/java/saramdle/blog/config/auth/CustomUserPrinciple.java
@@ -1,56 +1,24 @@
 package saramdle.blog.config.auth;
 
-import java.io.Serializable;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import lombok.Getter;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import saramdle.blog.config.auth.dto.LoginUser;
+import saramdle.blog.config.auth.dto.OAuthAttributes;
+import saramdle.blog.domain.User;
 
-public class CustomUserPrinciple implements OAuth2User, Serializable {
+@Getter
+public class CustomUserPrinciple extends DefaultOAuth2User {
 
     private LoginUser loginUser;
-    private Set<GrantedAuthority> authorities;
-    private Map<String, Object> oAuthAttributes;
 
-    public CustomUserPrinciple(LoginUser loginUser, Collection<? extends GrantedAuthority> authorities, Map<String, Object> oAuthAttributes) {
-        this.loginUser = loginUser;
-        this.authorities = (authorities != null)
-                ? Collections.unmodifiableSet(new LinkedHashSet<>(this.sortAuthorities(authorities)))
-                : Collections.unmodifiableSet(new LinkedHashSet<>(AuthorityUtils.NO_AUTHORITIES));
-        this.oAuthAttributes = oAuthAttributes;
-    }
-
-    @Override
-    public Map<String, Object> getAttributes() {
-        return Collections.unmodifiableMap(oAuthAttributes);
-    }
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.unmodifiableSet(authorities);
-    }
-
-    @Override
-    public String getName() {
-        return loginUser.getEmail();
-    }
-
-    public LoginUser getLoginUser() {
-        return loginUser;
-    }
-
-    private Set<GrantedAuthority> sortAuthorities(Collection<? extends GrantedAuthority> authorities) {
-        SortedSet<GrantedAuthority> sortedAuthorities = new TreeSet<>(
-                Comparator.comparing(GrantedAuthority::getAuthority));
-        sortedAuthorities.addAll(authorities);
-        return sortedAuthorities;
+    public CustomUserPrinciple(User user, OAuthAttributes attributes) {
+        super(
+                Collections.singleton(new SimpleGrantedAuthority(user.getRole().toString())),
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey()
+        );
+        this.loginUser = new LoginUser(user);
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/config/auth/SessionConst.java
+++ b/back/blog/src/main/java/saramdle/blog/config/auth/SessionConst.java
@@ -1,8 +1,0 @@
-package saramdle.blog.config.auth;
-
-public class SessionConst {
-    public static final String LOGIN_USER = "loginUser";
-
-    private SessionConst() {
-    }
-}

--- a/back/blog/src/main/java/saramdle/blog/config/auth/UserPrinciple.java
+++ b/back/blog/src/main/java/saramdle/blog/config/auth/UserPrinciple.java
@@ -1,0 +1,52 @@
+package saramdle.blog.config.auth;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import saramdle.blog.config.auth.dto.SessionUser;
+
+public class UserPrinciple implements OAuth2User, Serializable {
+
+    private SessionUser user;
+    private Set<GrantedAuthority> authorities;
+    private Map<String, Object> oAuthAttributes;
+
+    public UserPrinciple(SessionUser user, Collection<? extends GrantedAuthority> authorities, Map<String, Object> oAuthAttributes) {
+        this.user = user;
+        this.authorities = (authorities != null)
+                ? Collections.unmodifiableSet(new LinkedHashSet<>(this.sortAuthorities(authorities)))
+                : Collections.unmodifiableSet(new LinkedHashSet<>(AuthorityUtils.NO_AUTHORITIES));
+        this.oAuthAttributes = oAuthAttributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Collections.unmodifiableMap(oAuthAttributes);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.unmodifiableSet(authorities);
+    }
+
+    @Override
+    public String getName() {
+        return user.getEmail();
+    }
+
+    private Set<GrantedAuthority> sortAuthorities(Collection<? extends GrantedAuthority> authorities) {
+        SortedSet<GrantedAuthority> sortedAuthorities = new TreeSet<>(
+                Comparator.comparing(GrantedAuthority::getAuthority));
+        sortedAuthorities.addAll(authorities);
+        return sortedAuthorities;
+    }
+}

--- a/back/blog/src/main/java/saramdle/blog/config/auth/dto/LoginUser.java
+++ b/back/blog/src/main/java/saramdle/blog/config/auth/dto/LoginUser.java
@@ -5,12 +5,12 @@ import lombok.Getter;
 import saramdle.blog.domain.User;
 
 @Getter
-public class SessionUser implements Serializable {
+public class LoginUser implements Serializable {
     private String email;
     private String name;
     private String picture;
 
-    public SessionUser(User user) {
+    public LoginUser(User user) {
         this.email = user.getEmail();
         this.name = user.getName();
         this.picture = user.getPicture();

--- a/back/blog/src/main/java/saramdle/blog/controller/HomeController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/HomeController.java
@@ -14,10 +14,10 @@ import saramdle.blog.config.auth.CustomUserPrinciple;
 public class HomeController {
 
     @GetMapping
-    public ResponseEntity home(@AuthenticationPrincipal CustomUserPrinciple user) {
-        if (user == null) {
+    public ResponseEntity home(@AuthenticationPrincipal CustomUserPrinciple userPrinciple) {
+        if (userPrinciple == null) {
              return ResponseEntity.ok("비로그인 요청");
         }
-        return ResponseEntity.ok(user.getUser());
+        return ResponseEntity.ok(userPrinciple.getLoginUser());
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/controller/HomeController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/HomeController.java
@@ -1,30 +1,23 @@
 package saramdle.blog.controller;
 
-import static saramdle.blog.config.auth.SessionConst.LOGIN_USER;
-
-import javax.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-import saramdle.blog.config.auth.dto.SessionUser;
+import saramdle.blog.config.auth.CustomUserPrinciple;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 public class HomeController {
-    
-    private final HttpSession session;
-    
-    @GetMapping
-    public ResponseEntity home() {
-        SessionUser sessionUser = (SessionUser) session.getAttribute(LOGIN_USER);
 
-        if (sessionUser == null) {
+    @GetMapping
+    public ResponseEntity home(@AuthenticationPrincipal CustomUserPrinciple user) {
+        if (user == null) {
              return ResponseEntity.ok("비로그인 요청");
         }
-
-        return ResponseEntity.ok(sessionUser);
+        return ResponseEntity.ok(user.getUser());
     }
 }


### PR DESCRIPTION
## PR Summary

-  시큐리티 Filter들을 모두 거쳐 인증에 통과한 User가 특정 Controller에 도달했을 때, User 정보를 주입해주는 Principal 객체를 커스텀했습니다.

## Changes
- CustomOAuth2UserService에서 loadUser()를 호출해 로그인을 진행한 후 반환해줄 인증 객체를 커스텀하여 생성하였습니다.
   → `CustomUserPrinciple`
- 로그인 진행 후 `"/"`로 홈 화면 요청 시 현재 사용자의 이름, 이메일, 프로필 사진을 응답 데이터로 보내도록 변경하였습니다.
```json
{
  "email": "test@gmail.com",
  "name": "test",
  "picture": "https://lh3.googleusercontent.com/a/AGNmyxY2C5SRZwEyl0jZtGn1Q-RUf3yhcLgundM5DLsOzg=s96-c"
}
```


