### PR TITLE
feat : 로그인된 사용자 정보로 게시물 및 댓글 API를 처리하는 기능 구현

### DIFF
--- a/back/blog/src/main/java/saramdle/blog/config/auth/CustomUserPrinciple.java
+++ b/back/blog/src/main/java/saramdle/blog/config/auth/CustomUserPrinciple.java
@@ -21,4 +21,8 @@ public class CustomUserPrinciple extends DefaultOAuth2User {
         );
         this.loginUser = new LoginUser(user);
     }
+
+    public String getUserEmail() {
+        return loginUser.getEmail();
+    }
 }

--- a/back/blog/src/main/java/saramdle/blog/config/auth/SecurityConfig.java
+++ b/back/blog/src/main/java/saramdle/blog/config/auth/SecurityConfig.java
@@ -25,6 +25,8 @@ public class SecurityConfig {
                     .anyRequest().authenticated()
                 .and()
                     .logout()
+                        .invalidateHttpSession(true)
+                        .deleteCookies("JSESSIONID")
                         .logoutSuccessUrl("/")
                 .and()
                     .oauth2Login()

--- a/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
@@ -63,7 +63,7 @@ public class CommentController {
     @PutMapping("/{commentId}")
     @ResponseBody
     public ResponseEntity<CommentResponseDto> updateComment(@RequestBody CommentRequestDto commentRequestDto, @PathVariable Long commentId) {
-        commentId = commentService.updateComment(commentId, toEntity(commentRequestDto));
+        commentId = commentService.updateComment(commentId, commentRequestDto);
         Comment comment = commentService.findComment(commentId);
         return ResponseEntity.ok(toDto(comment));
     }
@@ -73,13 +73,6 @@ public class CommentController {
     public ResponseEntity<String> deleteComment(@PathVariable Long commentId) {
         commentService.deleteComment(commentId);
         return ResponseEntity.ok("댓글 삭제 성공");
-    }
-    
-    private Comment toEntity(CommentRequestDto commentRequestDto) {
-        return Comment.builder()
-                .contents(commentRequestDto.getContents())
-                .post(postService.findPost(commentRequestDto.getPostId()))
-                .build();
     }
 
     private Comment toEntity(CommentRequestDto commentRequestDto, User user) {

--- a/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/CommentController.java
@@ -94,7 +94,7 @@ public class CommentController {
         return CommentResponseDto.builder()
                 .id(comment.getId())
                 .contents(comment.getContents())
-                .user(comment.getUser())
+                .author(comment.getUser().getEmail())
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/back/blog/src/main/java/saramdle/blog/controller/PostController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/PostController.java
@@ -68,7 +68,7 @@ public class PostController {
 
     @PutMapping("/{id}")
     public ResponseEntity<PostResponseDto> update(@PathVariable long id, @RequestBody PostRequestDto postRequestDto) {
-        Long postId = postService.update(id, toEntity(postRequestDto));
+        Long postId = postService.update(id, postRequestDto);
         Post post = postService.findPost(postId);
         return ResponseEntity.ok(toDto(post));
     }
@@ -87,14 +87,6 @@ public class PostController {
                 .author(post.getUser().getEmail())
                 .imgUrl(post.getImgUrl())
                 .createdAt(post.getCreatedAt())
-                .build();
-    }
-
-    private Post toEntity(PostRequestDto postRequestDto) {
-        return Post.builder()
-                .title(postRequestDto.getTitle())
-                .contents(postRequestDto.getContents())
-                .imgUrl(postRequestDto.getImgUrl())
                 .build();
     }
 

--- a/back/blog/src/main/java/saramdle/blog/controller/PostController.java
+++ b/back/blog/src/main/java/saramdle/blog/controller/PostController.java
@@ -84,7 +84,7 @@ public class PostController {
                 .id(post.getId())
                 .title(post.getTitle())
                 .contents(post.getContents())
-                .user(post.getUser())
+                .author(post.getUser().getEmail())
                 .imgUrl(post.getImgUrl())
                 .createdAt(post.getCreatedAt())
                 .build();

--- a/back/blog/src/main/java/saramdle/blog/domain/CommentRequestDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/CommentRequestDto.java
@@ -9,13 +9,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentRequestDto {
     private String contents;
-    private User user;
     private Long postId;
 
     @Builder
-    private CommentRequestDto(String contents, User user, Long postId) {
+    private CommentRequestDto(String contents, Long postId) {
         this.contents = contents;
-        this.user = user;
         this.postId = postId;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/CommentResponseDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/CommentResponseDto.java
@@ -11,14 +11,14 @@ import lombok.NoArgsConstructor;
 public class CommentResponseDto {
     private Long id;
     private String contents;
-    private User user;
+    private String author;
     private LocalDateTime createdAt;
 
     @Builder
-    private CommentResponseDto(Long id, String contents, User user, LocalDateTime createdAt) {
+    private CommentResponseDto(Long id, String contents, String author, LocalDateTime createdAt) {
         this.id = id;
         this.contents = contents;
-        this.user = user;
+        this.author = author;
         this.createdAt = createdAt;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/PostRequestDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/PostRequestDto.java
@@ -10,14 +10,12 @@ import lombok.NoArgsConstructor;
 public class PostRequestDto {
     private String title;
     private String contents;
-    private User user;
     private String imgUrl;
 
     @Builder
-    private PostRequestDto(String title, String contents, User user, String imgUrl) {
+    private PostRequestDto(String title, String contents, String imgUrl) {
         this.title = title;
         this.contents = contents;
-        this.user = user;
         this.imgUrl = imgUrl;
     }
 }

--- a/back/blog/src/main/java/saramdle/blog/domain/PostResponseDto.java
+++ b/back/blog/src/main/java/saramdle/blog/domain/PostResponseDto.java
@@ -12,17 +12,17 @@ public class PostResponseDto {
     private Long id;
     private String title;
     private String contents;
-    private User user;
+    private String author;
     private String imgUrl;
     private LocalDateTime createdAt;
 
     @Builder
-    private PostResponseDto(Long id, String title, String contents, User user,
+    private PostResponseDto(Long id, String title, String contents, String author,
                             String imgUrl, LocalDateTime createdAt) {
         this.id = id;
         this.title = title;
         this.contents = contents;
-        this.user = user;
+        this.author = author;
         this.imgUrl = imgUrl;
         this.createdAt = createdAt;
     }

--- a/back/blog/src/main/java/saramdle/blog/service/CommentService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/CommentService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import saramdle.blog.domain.Comment;
 import saramdle.blog.domain.CommentRepository;
+import saramdle.blog.domain.CommentRequestDto;
 import saramdle.blog.domain.exception.NotFoundException;
 
 @Service
@@ -34,7 +35,7 @@ public class CommentService {
     }
 
     @Transactional
-    public Long updateComment(Long commentId, Comment updateParam) {
+    public Long updateComment(Long commentId, CommentRequestDto updateParam) {
         Comment comment = findComment(commentId);
         comment.update(updateParam.getContents());
 

--- a/back/blog/src/main/java/saramdle/blog/service/PostService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/PostService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import saramdle.blog.domain.Post;
 import saramdle.blog.domain.PostRepository;
+import saramdle.blog.domain.PostRequestDto;
 import saramdle.blog.domain.exception.NotFoundException;
 
 @Service
@@ -33,7 +34,7 @@ public class PostService {
     }
 
     @Transactional
-    public Long update(Long postId, Post updateParam) {
+    public Long update(Long postId, PostRequestDto updateParam) {
         Post post = findPost(postId);
         post.update(updateParam.getTitle(), updateParam.getContents(), updateParam.getImgUrl());
         return postId;

--- a/back/blog/src/main/java/saramdle/blog/service/UserService.java
+++ b/back/blog/src/main/java/saramdle/blog/service/UserService.java
@@ -1,0 +1,23 @@
+package saramdle.blog.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import saramdle.blog.domain.User;
+import saramdle.blog.domain.UserRepository;
+import saramdle.blog.domain.exception.NotFoundException;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+    private static final String NOT_FOUND_USER = "EMAIL[%s] 회원을 찾을 수 없습니다.";
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public User findUser(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(String.format(NOT_FOUND_USER, email)));
+    }
+}

--- a/back/blog/src/test/java/saramdle/blog/domain/common/BaseTimeEntityTest.java
+++ b/back/blog/src/test/java/saramdle/blog/domain/common/BaseTimeEntityTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import saramdle.blog.domain.Comment;
+import saramdle.blog.domain.CommentRequestDto;
 import saramdle.blog.domain.Post;
 import saramdle.blog.domain.PostRequestDto;
 import saramdle.blog.service.CommentService;
@@ -69,8 +70,8 @@ class BaseTimeEntityTest {
         Long commentId = commentService.save(comment);
         Comment oldComment = commentService.findComment(commentId);
 
-        Comment updateComment = Comment.builder().contents("내용2").build();
-        commentService.updateComment(commentId, updateComment);
+        CommentRequestDto updateParam = CommentRequestDto.builder().contents("내용2").build();
+        commentService.updateComment(commentId, updateParam);
         Comment newComment = commentService.findComment(commentId);
 
         LocalDateTime oldTime = oldComment.getUpdatedAt();

--- a/back/blog/src/test/java/saramdle/blog/domain/common/BaseTimeEntityTest.java
+++ b/back/blog/src/test/java/saramdle/blog/domain/common/BaseTimeEntityTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import saramdle.blog.domain.Comment;
 import saramdle.blog.domain.Post;
+import saramdle.blog.domain.PostRequestDto;
 import saramdle.blog.service.CommentService;
 import saramdle.blog.service.PostService;
 
@@ -52,8 +53,8 @@ class BaseTimeEntityTest {
         Long postId = postService.save(post);
         Post oldPost = postService.findPost(postId);
 
-        Post updatePost = Post.builder().title("제목2").contents("내용2").build();
-        postService.update(postId, updatePost);
+        PostRequestDto updateParam = PostRequestDto.builder().title("제목2").contents("내용2").build();
+        postService.update(postId, updateParam);
         Post newPost = postService.findPost(postId);
 
         LocalDateTime oldTime = oldPost.getUpdatedAt();

--- a/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/CommentServiceTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import saramdle.blog.domain.Comment;
+import saramdle.blog.domain.CommentRequestDto;
 import saramdle.blog.domain.Post;
 import saramdle.blog.domain.exception.NotFoundException;
 
@@ -67,8 +68,8 @@ class CommentServiceTest {
         Comment comment = Comment.builder().post(post).build();
         Long commentId = commentService.save(comment);
 
-        Comment newComment = Comment.builder().contents("Hello World").build();
-        Long updatedCommentId = commentService.updateComment(commentId, newComment);
+        CommentRequestDto updateParam = CommentRequestDto.builder().contents("Hello World").build();
+        Long updatedCommentId = commentService.updateComment(commentId, updateParam);
 
         Comment result = commentService.findComment(updatedCommentId);
         assertThat(result.getContents()).isEqualTo("Hello World");

--- a/back/blog/src/test/java/saramdle/blog/service/PostServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/PostServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import saramdle.blog.domain.Post;
 import saramdle.blog.domain.PostRepository;
+import saramdle.blog.domain.PostRequestDto;
 import saramdle.blog.domain.exception.NotFoundException;
 
 @Transactional
@@ -72,7 +73,7 @@ class PostServiceTest {
                 .build();
         Long postId = postRepository.save(post).getId();
 
-        Post updateParam = Post.builder()
+        PostRequestDto updateParam = PostRequestDto.builder()
                 .title("제목2")
                 .contents("본문2")
                 .imgUrl("https://img.siksinhot.com/article/1638761259231391.jpg")

--- a/back/blog/src/test/java/saramdle/blog/service/UserServiceTest.java
+++ b/back/blog/src/test/java/saramdle/blog/service/UserServiceTest.java
@@ -1,0 +1,33 @@
+package saramdle.blog.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import saramdle.blog.domain.User;
+import saramdle.blog.domain.UserRepository;
+
+@Transactional
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @DisplayName("email로 회원을 조회합니다.")
+    @Test
+    void findUserByEmail() {
+        User user = User.builder().email("test@gmail.com").build();
+        User savedUser = userRepository.save(user);
+
+        User findUser = userService.findUser(savedUser.getEmail());
+
+        assertThat(findUser.getId()).isEqualTo(savedUser.getId());
+    }
+}


### PR DESCRIPTION
## PR Summary
컨트롤러에서 로그인된 회원 정보를 받아 게시물과 댓글 api 요청을 처리하도록 구현하였습니다.

## Changes

- 회원 `email`을 통해 DB에 저장된 회원을 조회하는 기능 구현 및 테스트 추가
- 게시물 및 댓글 저장 컨트롤러에서 시큐리티 인증 객체(`CustomUserPrinciple`)를 받아 게시물을 저장하도록 구현
- 게시물 및 댓글 조회 요청시 `author` 응답 데이터로 회원의 `email`을 반환하도록 변경
- 게시물 및 댓글 수정 서비스 로직에서 수정 파라미터를 엔티티가 아닌 DTO로 받아서 처리하도록 변경

## Test Checklist

- [x] `email`로 회원 조회 성공 테스트
- [x] 게시물 단건 조회 성공 응답 확인
<img width="361" alt="image" src="https://user-images.githubusercontent.com/91456818/234185381-073a147b-09b3-4fe6-aae6-ee9ab751c5c2.png">

- [x] 게시물 수정 성공 응답 확인
<img width="354" alt="image" src="https://user-images.githubusercontent.com/91456818/234185595-6b78ff6d-cfc4-45a1-8203-e41813cbd65f.png">

- [x] 댓글 조회 성공 응답 확인
<img width="379" alt="image" src="https://user-images.githubusercontent.com/91456818/234185978-cf7af62b-7a98-4cbb-b135-015e92029fe4.png">